### PR TITLE
Rename functions, use enums

### DIFF
--- a/src/MariaDB.jl
+++ b/src/MariaDB.jl
@@ -3,4 +3,5 @@ module MariaDB
     include(joinpath("mariadb", "errors.jl"))
     include(joinpath("mariadb", "types.jl"))
     include(joinpath("mariadb", "funcs.jl"))
+    include(joinpath("mariadb", "compat.jl"))
 end

--- a/src/mariadb/compat.jl
+++ b/src/mariadb/compat.jl
@@ -1,0 +1,89 @@
+# Create synonyms with the same names as the C MySQL/MariaDB client
+
+export MYSQL, mysql_error, MY_CHARSET_INFO, MYSQL_OK
+const MYSQL = DB
+const MYSQL_OK = DB_OK
+const mysql_error = last_error
+const MY_CHARSET_INFO = DB_CHARSET_INFO
+
+for fun in (:affected_rows, :autocommit, :change_user, :character_set_name, :close, :commit,
+    	    :data_seek, :dump_debug_info, :errno, :escape_string, :fetch_field, :fetch_fields,
+            :fetch_field_direct, :fetch_lengths, :fetch_row, :field_count, :field_seek,
+    	    :field_tell, :free_result, :get_character_set_info, :get_client_info,
+    	    :get_client_version, :get_host_info, :get_proto_info, :get_server_info,
+	    :get_server_version, :get_ssl_cipher, :hex_string, :info, :init, :insert_id,
+    	    :kill, :library_end, :library_init, :more_results, :next_result, :num_fields,
+    	    :num_rows, :options, :ping, :query, :real_connect, :real_escape_string,
+            :real_query, :refresh, :rollback, :row_seek, :row_tell, :select_db, :send_query,
+            :server_end, :server_init, :set_character_set, :set_server_option, :shutdown,
+            :sqlstate, :ssl_set, :stat, :store_result, :thread_end, :thread_id, :thread_init,
+            :thread_safe, :use_result, :warning_count)
+    sym = symbol(string("mysql_",fun))
+    @eval $sym = $fun
+    @eval export $sym
+end
+
+for typ in (:RES, :ROW, :FIELD_OFFSET, :ROW_OFFSET, :FIELD, :TIME)
+    sym = symbol(string("MYSQL_",typ))
+    @eval $sym = $(symbol(string("DB_",typ)))
+    @eval export $sym
+end
+
+for typ in (:TIMESTAMP_NONE, :TIMESTAMP_ERROR, :TIMESTAMP_DATE, :TIMESTAMP_DATETIME,
+    	    :TIMESTAMP_TIME, :OPTION, :OPT_CONNECT_TIMEOUT, :OPT_COMPRESS, :OPT_NAMED_PIPE,
+            :INIT_COMMAND, :READ_DEFAULT_FILE, :READ_DEFAULT_GROUP, :SET_CHARSET_DIR,
+            :SET_CHARSET_NAME, :OPT_LOCAL_INFILE, :OPT_PROTOCOL, :SHARED_MEMORY_BASE_NAME,
+            :OPT_READ_TIMEOUT, :OPT_WRITE_TIMEOUT, :OPT_USE_RESULT, :OPT_USE_REMOTE_CONNECTION,
+            :OPT_USE_EMBEDDED_CONNECTION, :OPT_GUESS_CONNECTION, :SET_CLIENT_IP, :SECURE_AUTH,
+    	    :REPORT_DATA_TRUNCATION, :OPT_RECONNECT, :OPT_SSL_VERIFY_SERVER_CERT, :PLUGIN_DIR,
+            :DEFAULT_AUTH, :ENABLE_CLEARTEXT_PLUGIN, :PROGRESS_CALLBACK, :OPT_NONBLOCK,
+            :NO_MORE_RESULTS, :SHUTDOWN_KILLABLE_CONNECT, :SHUTDOWN_KILLABLE_TRANS,
+    	    :SHUTDOWN_KILLABLE_LOCK_TABLE, :SHUTDOWN_KILLABLE_UPDATE, :SHUTDOWN_LEVEL)
+    sym = symbol(string("MYSQL_",typ))
+    @eval $sym = $typ
+    @eval export $sym
+end
+
+for typ in (:DEFAULT, :TCP, :SOCKET, :PIPE, :MEMORY)
+    sym = symbol(string("MYSQL_PROTOCOL_",typ))
+    @eval $sym = $typ
+    @eval export $sym
+end
+
+for typ in (:READY, :GET_RESULT, :USE_RESULT, :STATEMENT_GET_RESULT)
+    sym = symbol(string("MYSQL_STATUS_",typ))
+    @eval $sym = $typ
+    @eval export $sym
+end
+
+export SHUTDOWN_DEFAULT
+const  SHUTDOWN_DEFAULT = WAIT_DEFAULT
+for typ in (:CONNECTIONS, :TRANSACTIONS, :UPDATES, :ALL_BUFFERS, :CRITICAL_BUFFERS)
+    sym = symbol(string("SHUTDOWN_WAIT_",typ))
+    @eval $sym = $(symbol(string("WAIT_",typ)))
+    @eval export $sym
+end
+
+for sym in (:NOT_NULL, :PRI_KEY, :UNIQUE_KEY, :MULTIPLE_KEY, :BLOB, :UNSIGNED, :ZEROFILL,
+            :BINARY, :ENUM, :AUTO_INCREMENT, :TIMESTAMP, :SET, :NO_DEFAULT_VALUE, :ON_UPDATE_NOW,
+            :NUM, :UNIQUE, :BINCP, :GET_FIXED_FIELDS, :FIELD_IN_PART_FUNC)
+    @eval export $(symbol(string(sym,"_FLAG")))
+end
+
+for sym in (:LONG_PASSWORD, :FOUND_ROWS, :LONG_FLAG, :CONNECT_WITH_DB, :NO_SCHEMA, :COMPRESS,
+            :ODBC, :LOCAL_FILES, :IGNORE_SPACE, :PROTOCOL_41, :INTERACTIVE, :SSL, :IGNORE_SIGPIPE,
+            :TRANSACTIONS, :RESERVED, :SECURE_CONNECTION, :MULTI_STATEMENTS, :MULTI_RESULTS,
+            :PS_MULTI_RESULTS, :PLUGIN_AUTH, :PROGRESS, :SSL_VERIFY_SERVER_CERT)
+    @eval export $(symbol(string("CLIENT_",sym)))
+end
+
+for sym in (:GRANT, :LOG, :TABLES, :HOSTS, :STATUS, :THREADS, :SLAVE, :MASTER, :ERROR_LOG,
+            :ENGINE_LOG, :BINARY_LOG, :RELAY_LOG, :GENERAL_LOG, :SLOW_LOG, :READ_LOCK,
+            :CHECKPOINT, :QUERY_CACHE, :QUERY_CACHE_FREE, :DES_KEY_FILE, :USER_RESOURCES,
+            :TABLE_STATS, :INDEX_STATS, :USER_STATS, :FAST)
+    @eval export $(symbol(string("REFRESH_",sym)))
+end
+
+export MYSQL_OPTION_MULTI_STATEMENT_ON, MYSQL_OPTION_MULTI_STATEMENT_OFF
+const MYSQL_OPTION_MULTI_STATEMENT_ON  = MULTI_STATEMENT_ON
+const MYSQL_OPTION_MULTI_STATEMENT_OFF = MULTI_STATEMENT_OFF

--- a/src/mariadb/errors.jl
+++ b/src/mariadb/errors.jl
@@ -2,7 +2,7 @@
 # They are derived from:
 # https://mariadb.com/kb/en/mariadb/mariadb-connector-c
 
-const MYSQL_OK = 0
+const DB_OK = 0
 
 const ER_ERROR_FIRST = 1000
 const ER_HASHCHK = 1000
@@ -835,4 +835,4 @@ const CR_ALREADY_CONNECTED = 2058
 const CR_AUTH_PLUGIN_CANNOT_LOAD = 2059
 const CR_ERROR_LAST = 2059
 
-export MYSQL_OK
+export DB_OK

--- a/src/mariadb/funcs.jl
+++ b/src/mariadb/funcs.jl
@@ -7,11 +7,11 @@
 """
 # Description
 
-Returns the number of affected rows by the last operation associated with mysql, if the operation
+Returns the number of affected rows by the last operation associated with db, if the operation
 was an "upsert" (INSERT, UPDATE, DELETE or REPLACE) statement, or -1 if the last query failed.
 
 When using UPDATE, MariaDB will not update columns where the new value is the same as the old value.
-This creates the possibility that mysql_affected_rows may not actually equal the number of rows
+This creates the possibility that affected_rows may not actually equal the number of rows
 matched, only the number of rows that were literally affected by the query.
 The REPLACE statement first deletes the record with the same primary key and then inserts the new
 record. This function returns the number of deleted records in addition to the number of inserted
@@ -19,32 +19,32 @@ records.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_affected_rows(mysql::MYSQL) =
-    ccall( (:mysql_affected_rows, mariadb_lib), Culonglong, (Ptr{Void}, ), mysql.ptr)
+affected_rows(db::DB) =
+    ccall( (:mysql_affected_rows, mariadb_lib), Culonglong, (Ptr{Void}, ), db.ptr)
 
 """
 # Description
 
 Toggles autocommit mode on or off for the current database connection. Autocommit mode will be set
-if auto_mode=true or unset if auto_mode=false. Returns MYSQL_OK on success, or nonzero if an error
+if auto_mode=true or unset if auto_mode=false. Returns DB_OK on success, or nonzero if an error
 occurred.
 
 **Autocommit** mode only affects operations on transactional table types. To determine the current
-state of autocommit mode use the SQL command SELECT @@autocommit. Be aware: the *mysql_rollback()*
+state of autocommit mode use the SQL command SELECT @@autocommit. Be aware: the *rollback()*
 function will not work if autocommit mode is switched on.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **auto_mode** whether to turn autocommit on or not.
 """
-mysql_autocommit(mysql::MYSQL, auto_mode::Bool) =
+autocommit(db::DB, auto_mode::Bool) =
     ccall( (:mysql_autocommit, mariadb_lib), Cchar, (Ptr{Void}, Cchar),
-           mysql.ptr, Int8(auto_mode)) != 0
+           db.ptr, Int8(auto_mode)) != 0
 
 """
 # Description
@@ -55,26 +55,26 @@ In order to successfully change users a valid username and password parameters m
 that user must have sufficient permissions to access the desired database. If for any reason
 authorization fails, the current user authentication will remain.
 
-Returns MYSQL_OK on success, nonzero if an error occured.
+Returns DB_OK on success, nonzero if an error occured.
 
-**mysql_change_user** will always cause the current database connection to behave as if was a
+**change_user** will always cause the current database connection to behave as if was a
 completely new database connection, regardless of if the operation was completed successfully. This
 reset includes performing a rollback on any active transactions, closing all temporary tables, and
 unlocking all locked tables.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **user** the user name for server authentication
 - **passwd** the password for server authentication
 - **db** the default database. If desired, the empty string "" may be passed resulting in only
   changing the user and not selecting a database. To select a database in this case use the
-  *mysql_select_db()* function.
+  *select_db()* function.
 """
-mysql_change_user(mysql::MYSQL, user::ByteString, passwd::ByteString, db::ByteString = "") =
+change_user(db::DB, user::AbstractString, passwd::AbstractString, dbname::AbstractString = "") =
     ccall((:mysql_change_user, mariadb_lib), Cchar, (Ptr{Void}, Cstring, Cstring, Cstring),
-          mysql.ptr, user, passwd, (db == "" ? C_NULL : db))
+          db.ptr, user, passwd, (dbname == "" ? C_NULL : dbname))
 
 """
 # Description
@@ -83,11 +83,11 @@ Returns the default client character set for the specified connection.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_character_set_name(mysql::MYSQL) = bytestring(
-    ccall( (:mysql_character_set_name, mariadb_lib), Cstring, (Ptr{Void},), mysql.ptr))
+character_set_name(db::DB) = bytestring(
+    ccall( (:mysql_character_set_name, mariadb_lib), Cstring, (Ptr{Void},), db.ptr))
 
 """
 # Description
@@ -96,46 +96,46 @@ Closes a previously opened connection.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-function mysql_close(mysql::MYSQL)
-    mysql.ptr == C_NULL && return
-    ccall( (:mysql_close, mariadb_lib), Void, (Ptr{Void},), mysql.ptr)
-    mysql.ptr = C_NULL
+function close(db::DB)
+    db.ptr == C_NULL && return
+    ccall( (:mysql_close, mariadb_lib), Void, (Ptr{Void},), db.ptr)
+    db.ptr = C_NULL
 end
 
 """
 # Description
 
-Commits the current transaction for the specified database connection. Returns MYSQL_OK on success,
+Commits the current transaction for the specified database connection. Returns DB_OK on success,
 nonzero if an error occurred.
 
-Executing **mysql_commit()** will not affected the behaviour of *autocommit*. This means, any update
-or insert statements following mysql_commit() will be rolled back when the connection gets closed.
+Executing **commit()** will not affected the behaviour of *autocommit*. This means, any update
+or insert statements following commit() will be rolled back when the connection gets closed.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_commit(mysql::MYSQL) = ccall( (:mysql_commit, mariadb_lib), Cchar, (Ptr{Void},), mysql.ptr)
+commit(db::DB) = ccall( (:mysql_commit, mariadb_lib), Cchar, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
-The **mysql_data_seek()** function seeks to an arbitrary function result pointer specified by the
+The **data_seek()** function seeks to an arbitrary function result pointer specified by the
 offset in the result set.
 
 This function can only be used with buffered result sets obtained from the use of the
-*mysql_store_result* function.
+*store_result* function.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()*.
+- **result** a result set identifier returned by *store_result()*.
 - **offset** the field offset. Must be between 1 and the total number of rows.
 """
-mysql_data_seek(result::MYSQL_RES, offset::UInt64) =
+data_seek(result::DB_RES, offset::UInt64) =
     ccall( (:mysql_data_seek, mariadb_lib), Void, (Ptr{Void}, Culonglong), result.ptr, offset-1)
 
 """
@@ -144,15 +144,15 @@ mysql_data_seek(result::MYSQL_RES, offset::UInt64) =
 This function is designed to be executed by an user with the SUPER privilege and is used to dump
 server status information into the log for the MariaDB Server relating to the connection.
 
-Returns MYSQL_OK on success, nonzero if an error occurred.
+Returns DB_OK on success, nonzero if an error occurred.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_dump_debug_info(mysql::MYSQL) =
-    ccall( (:mysql_dump_debug_info, mariadb_lib), Cint, (Ptr{Void},), mysql.ptr)
+dump_debug_info(db::DB) =
+    ccall( (:mysql_dump_debug_info, mariadb_lib), Cint, (Ptr{Void},), db.ptr)
 
 """
 # Description
@@ -162,10 +162,10 @@ no error occurred.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_errno(mysql::MYSQL) = ccall( (:mysql_errno, mariadb_lib), Cuint, (Ptr{Void},), mysql.ptr)
+errno(db::DB) = ccall( (:mysql_errno, mariadb_lib), Cuint, (Ptr{Void},), db.ptr)
 
 """
 # Description
@@ -175,47 +175,47 @@ error occurred an empty string is returned.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_error(mysql::MYSQL) =
-    bytestring(ccall( (:mysql_error, mariadb_lib), Cstring, (Ptr{Void},), mysql.ptr))
+last_error(db::DB) =
+    bytestring(ccall( (:mysql_error, mariadb_lib), Cstring, (Ptr{Void},), db.ptr))
 
 """
 # Description
 
-Returns the definition of one column of a result set as a MYSQL_FIELD type. Call this function
+Returns the definition of one column of a result set as a DB_FIELD type. Call this function
 repeatedly to retrieve information about all columns in the result set.
 
 The field order will be reset if you execute a new SELECT query.
 In case only information for a specific field is required the field can be selected by using the
-*mysql_field_seek()* function or obtained by *mysql_fetch_field_direct()* function.
+*field_seek()* function or obtained by *fetch_field_direct()* function.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-mysql_fetch_field(result::MYSQL_RES) =
-    MYSQL_FIELD(unsafe_load(ccall( (:mysql_fetch_field, mariadb_lib), Ptr{_MYSQL_FIELD_},
-                                   (Ptr{Void},), result.ptr), 1))
+fetch_field(result::DB_RES) =
+    DB_FIELD(unsafe_load(ccall( (:mysql_fetch_field, mariadb_lib), Ptr{_DB_FIELD_},
+                                (Ptr{Void},), result.ptr), 1))
 
 """
 # Description
 
-This function serves an identical purpose to the mysql_fetch_field() function with the single
+This function serves an identical purpose to the fetch_field() function with the single
 difference that instead of returning one field at a time for each field, the fields are returned as
 an array. Each field contains the definition for a column of the result set.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-function mysql_fetch_fields(result::MYSQL_RES)
+function fetch_fields(result::DB_RES)
     num_fields = ccall( (:mysql_num_fields, mariadb_lib), Cuint, (Ptr{Void},), result.ptr)
-    fields = Vector{MYSQL_FIELD}(num_fields)
-    ptr = ccall( (:mysql_fetch_fields, mariadb_lib), Ptr{_MYSQL_FIELD_}, (Ptr{Void},), result.ptr)
+    fields = Vector{DB_FIELD}(num_fields)
+    ptr = ccall( (:mysql_fetch_fields, mariadb_lib), Ptr{_DB_FIELD_}, (Ptr{Void},), result.ptr)
     for i in 1:num_fields
-        fields[i] = MYSQL_FIELD(unsafe_load(ptr,i))
+        fields[i] = DB_FIELD(unsafe_load(ptr,i))
     end
     fields
 end
@@ -223,36 +223,36 @@ end
 """
 # Description
 
-Returns a pointer to a MYSQL_FIELD structure which contains field information from the specified
+Returns a pointer to a DB_FIELD structure which contains field information from the specified
 result set.
 
-The total number of fields can be obtained by *mysql_field_count()* or *mysql_num_fields()*.
+The total number of fields can be obtained by *field_count()* or *num_fields()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 - **fieldnr** the field number. This value must be within the range from 1 to number of fields.
 """
-mysql_fetch_field_direct(result::MYSQL_RES, fieldnr::UInt) =
-    MYSQL_FIELD(unsafe_load(ccall( (:mysql_fetch_field_direct, mariadb_lib),
-                                   Ptr{_MYSQL_FIELD_}, (Ptr{Void}, Cuint),
+fetch_field_direct(result::DB_RES, fieldnr::UInt) =
+    DB_FIELD(unsafe_load(ccall( (:mysql_fetch_field_direct, mariadb_lib),
+                                   Ptr{_DB_FIELD_}, (Ptr{Void}, Cuint),
                                    result.ptr, fieldnr-1), 1))
 
 """
 # Description
 
-The mysql_fetch_lengths() function returns an array containing the lengths of every column of the
+The fetch_lengths() function returns an array containing the lengths of every column of the
 current row within the result set (not including terminating zero character) or an empty array if an
 error occurred.
 
-**mysql_fetch_lengths()** is valid only for the current row of the result set. It returns an empty
-array if you call it before calling *mysql_fetch_row()* or after retrieving all rows in the result.
+**fetch_lengths()** is valid only for the current row of the result set. It returns an empty
+array if you call it before calling *fetch_row()* or after retrieving all rows in the result.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-function mysql_fetch_lengths(result::MYSQL_RES)
+function fetch_lengths(result::DB_RES)
     num_fields = ccall( (:mysql_num_fields, mariadb_lib), Cuint, (Ptr{Void},), result.ptr)
     ptr = ccall( (:mysql_fetch_lengths, mariadb_lib), Ptr{Culong}, (Ptr{Void},), result.ptr)
     ptr == C_NULL ? Culong[] : pointer_to_array(ptr, num_fields)
@@ -261,42 +261,35 @@ end
 """
 # Description
 
-Fetches one row of data from the result set and returns it as an array of ByteStrings (MYSQL_ROW),
+Fetches one row of data from the result set and returns it as an array of ByteStrings (DB_ROW),
 where each column is stored in an offset starting from 1 (one). Each subsequent call to this
 function will return the next row within the result set, or an empty array if there are no more
 rows.
 
 If a column contains a NULL value the corresponding element will be set to Void().
-Memory associated to MYSQL_ROW will be freed when calling mysql_free_result() function.
+Memory associated to DB_ROW will be freed when calling free_result() function.
 
 Returns empty vector if no row is available.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
 
-function mysql_fetch_row(result::MYSQL_RES)
+function fetch_row(result::DB_RES)
     row = Vector{Any}()
     ptr = ccall( (:mysql_fetch_row, mariadb_lib), Ptr{Ptr{UInt8}}, (Ptr{Void},), result.ptr)
     ptr == C_NULL &&
         return row
-    fields = mysql_fetch_fields(result)
-    lengths = mysql_fetch_lengths(result)
+    fields = fetch_fields(result)
+    lengths = fetch_lengths(result)
     for i in 1:length(fields)
         # Get Ptr{UInt8}
         colptr = unsafe_load(ptr,i)
-        if colptr == C_NULL
-            push!(row, Void())
-            continue
-        end
-        if fields[i].field_julia_type <: BINARY_PARSE_TYPES
-            push!(row, parse(fields[i].field_julia_type, bytestring(pointer_to_array(colptr, lengths[i]))))
-        elseif fields[i].field_julia_type <: BINARY_NO_PARSE_TYPES
-            push!(row, fields[i].field_julia_type(pointer_to_array(colptr, lengths[i])))
-        elseif fields[i].field_julia_type <: NO_BINARY_NO_PARSE_TYPES
-            push!(row, fields[i].field_julia_type(bytestring(pointer_to_array(colptr, lengths[i]))))
-        end
+        push!(row,
+              colptr == C_NULL
+              ? Void()
+              : dbparse(fields[i].julia_type, pointer_to_array(colptr, lengths[i])))
     end
     return row
 end
@@ -305,50 +298,50 @@ end
 # Description
 
 Returns the number of columns for the most recent query on the connection represented by the link
-parameter as an unsigned integer. This function can be useful when using the *mysql_store_result()*
+parameter as an unsigned integer. This function can be useful when using the *store_result()*
 function to determine if the query should have produced a non-empty result set or not without
 knowing the nature of the query.
 
-The mysql_field_count() function should be used to determine if there is a result set available.
+The field_count() function should be used to determine if there is a result set available.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_field_count(mysql::MYSQL) =
-    ccall( (:mysql_field_count, mariadb_lib), Cuint, (Ptr{Void},), mysql.ptr)
+field_count(db::DB) =
+    ccall( (:mysql_field_count, mariadb_lib), Cuint, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
-Sets the field cursor to the given offset. The next call to mysql_fetch_field() will retrieve the
+Sets the field cursor to the given offset. The next call to fetch_field() will retrieve the
 field definition of the column associated with that offset.
 
 Returns the previous value of the field cursor.
 
-The number of fields can be obtained from *mysql_field_count()*.
+The number of fields can be obtained from *field_count()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 - **offset** the field number. This number must be in the range from 1..number of fields.
 """
-mysql_field_seek(result::MYSQL_RES, offset::MYSQL_FIELD_OFFSET) =
+field_seek(result::DB_RES, offset::DB_FIELD_OFFSET) =
     ccall( (:mysql_field_seek, mariadb_lib), Cuint, (ptr{Void}, Cuint),
            result.ptr, offset-1) + 1
 
 """
 # Description
 
-Return the offset of the field cursor used for the last *mysql_fetch_field()* call. This value can
-be used as a parameter for the function *mysql_field_seek()*.
+Return the offset of the field cursor used for the last *fetch_field()* call. This value can
+be used as a parameter for the function *field_seek()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-mysql_field_tell(result::MYSQL_RES) =
+field_tell(result::DB_RES) =
     ccall( (:mysql_field_tell, mariadb_lib), Cuint, (Ptr{Void},), result.ptr) + 1
 
 """
@@ -356,15 +349,15 @@ mysql_field_tell(result::MYSQL_RES) =
 
 Frees the memory associated with a result set.
 
-You should always free your result set with **mysql_free_result()** as soon it's not needed anymore.
-Row values obtained by a prior *mysql_fetch_row()* call will become invalid after calling
-*mysql_free_result()*.
+You should always free your result set with **free_result()** as soon it's not needed anymore.
+Row values obtained by a prior *fetch_row()* call will become invalid after calling
+*free_result()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-function mysql_free_result(result::MYSQL_RES)
+function free_result(result::DB_RES)
     result.ptr == C_NULL && return
     ccall( (:mysql_free_result, mariadb_lib), Void, (Ptr{Void},), result.ptr)
     result.ptr = C_NULL
@@ -376,17 +369,17 @@ end
 Returns information about the current default character set for the specified connection.
 
 A complete list of supported character sets in the client library is listed in the function
-description for *mysql_set_character_set_info()*.
+description for *set_character_set_info()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-function mysql_get_character_set_info(mysql::MYSQL)
+function get_character_set_info(db::DB)
     info = _MY_CHARSET_INFO_[_MY_CHARSET_INFO_()]
     ccall( (:mysql_get_character_set_info, mariadb_lib), Void, (Ptr{Void}, Ref{_MY_CHARSET_INFO_}),
-            mysql.ptr, info)
+            db.ptr, info)
     return MY_CHARSET_INFO(info[1])
 end
 
@@ -395,19 +388,19 @@ end
 
 Returns a string representing the client library version.
 
-To obtain the numeric value of the client library version use *mysql_get_client_version()*.
+To obtain the numeric value of the client library version use *get_client_version()*.
 """
-mysql_get_client_info() = bytestring(
-    ccall( (:mysql_get_client_info, mariadb_lib), Ptr{UInt8}, ()))
+get_client_info() =
+    bytestring(ccall( (:mysql_get_client_info, mariadb_lib), Ptr{UInt8}, ()))
 
 """
 # Description
 
 Returns a number representing the client library version.
 
-To obtain a string containing the client library version use the *mysql_get_client_info()* function.
+To obtain a string containing the client library version use the *get_client_info()* function.
 """
-mysql_get_client_version() = ccall( (:mysql_get_client_version, mariadb_lib), Culong, ())
+get_client_version() = ccall( (:mysql_get_client_version, mariadb_lib), Culong, ())
 
 """
 # Description
@@ -417,14 +410,14 @@ a string, or "" if the connection is not valid.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
     """
 
 _wrap_null(ptr::Ptr{UInt8}) = (ptr == C_NULL) ? "" : bytestring(ptr)
 
-mysql_get_host_info(mysql::MYSQL) =
-    _wrap_null(ccall( (:mysql_get_host_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+get_host_info(db::DB) =
+    _wrap_null(ccall( (:mysql_get_host_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
@@ -435,26 +428,26 @@ The client library doesn't support protocol version 9 and prior.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_get_proto_info(mysql::MYSQL) =
-    ccall( (:mysql_get_proto_info, mariadb_lib), Cuint, (Ptr{Void},), mysql.ptr)
+get_proto_info(db::DB) =
+    ccall( (:mysql_get_proto_info, mariadb_lib), Cuint, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
 Returns the server version or "" on failure.
 
-To obtain the numeric server version please use mysql_get_server_version().
+To obtain the numeric server version please use get_server_version().
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_get_server_info(mysql::MYSQL) =
-    _wrap_null(ccall( (:mysql_get_server_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+get_server_info(db::DB) =
+    _wrap_null(ccall( (:mysql_get_server_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
@@ -465,11 +458,11 @@ The form of the version number is VERSION_MAJOR * 10000 + VERSION_MINOR * 100 + 
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_get_server_version(mysql::MYSQL) =
-    ccall( (:mysql_get_server_version, mariadb_lib), Culong, (Ptr{Void},), mysql.ptr)
+get_server_version(db::DB) =
+    ccall( (:mysql_get_server_version, mariadb_lib), Culong, (Ptr{Void},), db.ptr)
 
 """
 # Description
@@ -478,11 +471,11 @@ Returns the name of the currently used cipher of the ssl connection, or "" for n
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_get_ssl_cipher(mysql::MYSQL) =
-    _wrap_null(ccall( (:mysql_get_ssl_cipher, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+get_ssl_cipher(db::DB) =
+    _wrap_null(ccall( (:mysql_get_ssl_cipher, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
@@ -496,7 +489,7 @@ Returns the hexadecimal encoded string.
 
 - **from** the string which will be encoded
 """
-function mysql_hex_string(from::ByteString)
+function hex_string(from::AbstractString)
     num_bytes = sizeof(from)
     out = Vector{UInt8}(num_bytes * 2 + 1)
     len = ccall( (:mysql_hex_string, mariadb_lib), Culong, (Ptr{UInt8}, Ptr{UInt8}, Culong),
@@ -520,86 +513,86 @@ provided below:
 | UPDATE ...                             | Rows matched: 40 Changed: 40 Warnings: 0     |
 
 Queries which do not fall into one of the preceding formats are not supported
-(e.g. `SELECT ...`). In these situations mysql_info() will return an empty string.
+(e.g. `SELECT ...`). In these situations info() will return an empty string.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_info(mysql::MYSQL) =
-    _wrap_null(ccall( (:mysql_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+info(db::DB) =
+    _wrap_null(ccall( (:mysql_info, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
 
-Prepares and initializes a MYSQL structure to be used with mysql_real_connect().
+Prepares and initializes a DB structure to be used with real_connect().
 
-If mysql_thread_init() was not called before, mysql_init() will also initialize the thread subsystem
+If thread_init() was not called before, init() will also initialize the thread subsystem
 for the current thread.
 
-Any subsequent calls to any mysql function (except *mysql_options()*) will fail until
-*mysql_real_connect()* was called.
-Memory allocated by **mysql_init()** must be freed with *mysql_close()*.
+Any subsequent calls to any database function (except *options()*) will fail until
+*real_connect()* was called.
+Memory allocated by **init()** must be freed with *close()*.
 """
-mysql_init() = MYSQL(ccall( (:mysql_init, mariadb_lib), Ptr{Void}, (Ptr{Void},), C_NULL))
+init() = DB(ccall( (:mysql_init, mariadb_lib), Ptr{Void}, (Ptr{Void},), C_NULL))
 
 """
 # Descriiption
 
-The **mysql_insert_id()** function returns the ID generated by a query on a table with a column
+The **insert_id()** function returns the ID generated by a query on a table with a column
 having the AUTO_INCREMENT attribute. If the last query wasn't an INSERT or UPDATE statement or if
 the modified table does not have a column with the AUTO_INCREMENT attribute, this function will
 return zero.
 
 Performing an INSERT or UPDATE statement using the LAST_INSERT_ID() function will also modify the
-value returned by the mysql_insert_id() function.
-When performing a multi insert statement, mysql_insert_id() will return the value of the first row.
+value returned by the insert_id() function.
+When performing a multi insert statement, insert_id() will return the value of the first row.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_insert_id(mysql::MYSQL) =
-    ccall( (:mysql_insert_id, mariadb_lib), Culonglong, (Ptr{UInt8},), mysql.ptr)
+insert_id(db::DB) =
+    ccall( (:mysql_insert_id, mariadb_lib), Culonglong, (Ptr{UInt8},), db.ptr)
 
 """
 # Description
 
 This function is used to ask the server to kill a MariaDB thread specified by the processid
 parameter. This value must be retrieved by SHOW PROCESSLIST. If trying to kill the own connection
-mysql_thread_id() should be used.
+thread_id() should be used.
 
-Returns MYSQL_OK on success, otherwise nonzero.
+Returns DB_OK on success, otherwise nonzero.
 
-To stop a running command without killing the connection use KILL QUERY. The mysql_kill() function
+To stop a running command without killing the connection use KILL QUERY. The kill() function
 only kills a connection, it doesn't free any memory - this must be done explicitly by calling
-*mysql_close()*.
+*close()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **pid** process id.
 """
-mysql_kill(mysql::MYSQL, pid::UInt) = call( (:mysql_kill, mariadb_lib), Cint, (PTr{UInt8}, Culong),
-                                             mysql.ptr, pid)
+kill(db::DB, pid::UInt) = call( (:mysql_kill, mariadb_lib), Cint, (PTr{UInt8}, Culong),
+                                             db.ptr, pid)
 
 
 """
 # Description
 
-**mysql_server_end()** is an alias for *mysql_library_end()*.
+**server_end()** is an alias for *library_end()*.
 """
-mysql_server_end() = ccall( (:mysql_server_end, mariadb_lib), Void, ())
+server_end() = ccall( (:mysql_server_end, mariadb_lib), Void, ())
 
 """
 # Description
 
-**mysql_server_init()** is an alias for *mysql_library_init()*.
+**server_init()** is an alias for *library_init()*.
 """
-function mysql_server_init(argv::Vector{ByteString}, groups::Vector{ByteString})
+function server_init(argv::Vector{ByteString}, groups::Vector{ByteString})
     c_groups::Vector{Ptr{UInt8}}
     for s in groups
         push!(c_groups, pointer(s))
@@ -610,12 +603,12 @@ function mysql_server_init(argv::Vector{ByteString}, groups::Vector{ByteString})
                    length(argv), argv, c_groups)
 end
 
-mysql_server_init(argv::Vector{ByteString}) =
+server_init(argv::Vector{ByteString}) =
     ccall( (:mysql_server_init, mariadb_lib), Cint,
            (Cint, Ptr{Ptr{UInt8}}, Ptr{Ptr{UInt8}}),
            length(argv), argv, C_NULL)
 
-mysql_server_init() =
+server_init() =
     ccall( (:mysql_server_init, mariadb_lib), Cint,
            (Cint, Ptr{Ptr{UInt8}}, Ptr{Ptr{UInt8}}),
            0, C_NULL, C_NULL)
@@ -627,63 +620,63 @@ Call when finished using the library, such as after disconnecting from the serve
 server application, the embedded server is shut down and cleaned up. For a client program, only
 cleans up by performing memory management tasks.
 
-*mysql_server_end()* is an alias
+*server_end()* is an alias
 """
-mysql_library_end() = mysql_server_end()
+library_end() = server_end()
 
 """
 # Description
 
 Call to initialize the library before calling other functions, both for embedded servers and regular
 clients. If used on an embedded server, the server is started and subsystems initialized. Returns
-MYSQL_OK for success, or nonzero if an error occurred.
+DB_OK for success, or nonzero if an error occurred.
 
-Call *mysql_library_end()* to clean up after completion.
+Call *library_end()* to clean up after completion.
 
-*mysql_server_init()* is an alias.
+*server_init()* is an alias.
 
 # Parameters
 - **argv** The arguments to pass into the init function, If used, the first parameter should be the
     process name
 - **groups** The groups to pass into the init function.
 """
-mysql_library_init(argv::Vector{ByteString}, groups::Vector{ByteString}) = mysql_server_init(argv, groups)
-mysql_library_init(argv::Vector{ByteString}) = mysql_server_init(argv)
-mysql_library_init() = mysql_server_init()
+library_init(argv::Vector{ByteString}, groups::Vector{ByteString}) = server_init(argv, groups)
+library_init(argv::Vector{ByteString}) = server_init(argv)
+library_init() = server_init()
 
 """
 # Description
 
-Indicates if one or more result sets are available from a previous call to *mysql_real_query()*.
+Indicates if one or more result sets are available from a previous call to *real_query()*.
 Returns true if more result sets are available, otherwise false.
 
-The function *mysql_set_server_option()* enables or disables multi statement support.
+The function *set_server_option()* enables or disables multi statement support.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_more_results(mysql::MYSQL) =
-    ccall( (:mysql_more_results, mariadb_lib), Cchar, (Ptr{Void},), mysql.ptr) == 1
+more_results(db::DB) =
+    ccall( (:mysql_more_results, mariadb_lib), Cchar, (Ptr{Void},), db.ptr) == 1
 
 """
 # Description
 
-Prepares next result set from a previous call to *mysql_real_query()* which can be retrieved by
-*mysql_store_result()* or *mysql_use_result()*. Returns MYSQL_OK on success, nonzero if an error
+Prepares next result set from a previous call to *real_query()* which can be retrieved by
+*store_result()* or *use_result()*. Returns DB_OK on success, nonzero if an error
 occurred.
 
-If a multi query contains errors the return value of *mysql_errno/error()* might change and there
+If a multi query contains errors the return value of *errno/error()* might change and there
 will be no result set available.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_next_result(mysql::MYSQL) =
-    ccall( (:mysql_next_result, mariadb_lib), Cint, (Ptr{Void},), mysql.ptr)
+next_result(db::DB) =
+    ccall( (:mysql_next_result, mariadb_lib), Cint, (Ptr{Void},), db.ptr)
 
 """
 # Description
@@ -692,9 +685,9 @@ Returns number of fields in a specified result set.
 
 # Parameters
 
-- **Result** A result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **Result** A result set identifier returned by *store_result()* or *use_result()*.
 """
-mysql_num_fields(result::MYSQL_RES) =
+num_fields(result::DB_RES) =
     ccall( (:mysql_num_fields, mariadb_lib), Cuint, (Ptr{Void},), result.ptr)
 
 """
@@ -702,134 +695,126 @@ mysql_num_fields(result::MYSQL_RES) =
 
 Returns number of rows in a result set.
 
-The behaviour of mysql_num_rows() depends on whether buffered or unbuffered result sets are being
-used. For unbuffered result sets, *mysql_num_rows()* will not return the correct number of rows
+The behaviour of num_rows() depends on whether buffered or unbuffered result sets are being
+used. For unbuffered result sets, *num_rows()* will not return the correct number of rows
 until all the rows in the result have been retrieved.
 
 # Parameters
 
-- **Result** A result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **Result** A result set identifier returned by *store_result()* or *use_result()*.
 """
-mysql_num_rows(result::MYSQL_RES) =
+num_rows(result::DB_RES) =
     ccall( (:mysql_num_rows, mariadb_lib), Culonglong, (Ptr{Void},), result.ptr)
 
 """
 # Description
 
 Used to set extra connect options and affect behavior for a connection. This function may be called
-multiple times to set several options. *mysql_options()* should be called after *mysql_init()* and
-before *mysql_real_connect()*.
+multiple times to set several options. *options()* should be called after *init()* and
+before *real_connect()*.
 
-Returns MYSQL_OK on success, non zero if an error occurred (invalid option or value).
+Returns DB_OK on success, non zero if an error occurred (invalid option or value).
 
 ## Options
 
-- **MYSQL_INIT_COMMAND** Command(s) which will be executed when connecting and reconnecting to the
+- **INIT_COMMAND** Command(s) which will be executed when connecting and reconnecting to the
     server.
     ```
-    mysql_options(mysql, MYSQL_INIT_COMMAND, "CREATE TABLE ...")
+    options(db, INIT_COMMAND, "CREATE TABLE ...")
     ```
 
-- **MYSQL_OPT_COMPRESS** Use the compressed protocol for client server communication. If the server
+- **DB_OPT_COMPRESS** Use the compressed protocol for client server communication. If the server
     doesn't support compressed protocol, the default protocol will be used.
     ```
-    mysql_options(mysql, MYSQL_OPT_COMPRESS)
+    options(db, OPT_COMPRESS)
     ```
 
-- **MYSQL_OPT_CONNECT_TIMEOUT** Connect timeout in seconds. This value will be passed as an unsigned
+- **OPT_CONNECT_TIMEOUT** Connect timeout in seconds. This value will be passed as an unsigned
     int parameter.
     ```
-    mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, 5)
+    options(db, OPT_CONNECT_TIMEOUT, 5)
     ```
 
-- **MYSQL_OPT_LOCAL_INFILE** Enable or disable use of LOAD DATA LOCAL INFILE
+- **OPT_LOCAL_INFILE** Enable or disable use of LOAD DATA LOCAL INFILE
     ```
-    mysql_options(mysql, MYSQL_OPT_LOCAL_INFILE)        /* disable */
-    mysql_options(mysql, MYSQL_OPT_LOCAL_INFILE, "1")   /* enable */
+    options(db, OPT_LOCAL_INFILE)        /* disable */
+    options(db, OPT_LOCAL_INFILE, "1")   /* enable */
     ```
 
-- **MYSQL_OPT_NAMED_PIPE** For Windows operating systems only: Use named pipes for client/server
+- **OPT_NAMED_PIPE** For Windows operating systems only: Use named pipes for client/server
     communication.
     ```
-    mysql_options(mysql, MYSQL_OPT_NAMED_PIPE)
+    options(db, OPT_NAMED_PIPE)
     ```
 
-- **MYSQL_OPT_PROTOCOL** Specify the type of client/server protocol. Possible values are:
-    - MYSQL_PROTOCOL_TCP
-    - MYSQL_PROTOCOL_SOCKET
-    - MYSQL_PROTOCOL_PIPE
+- **OPT_PROTOCOL** Specify the type of client/server protocol. Possible values are:
+    - PROTOCOL_TCP
+    - PROTOCOL_SOCKET
+    - PROTOCOL_PIPE
     ```
-    mysql_options(mysql, MYSQL_OPT_PROTOCOL, MYSQL_PROTOCOL_SOCKET)
-    ```
-
-- **MYSQL_OPT_RECONNECT** Enable or disable automatic reconnect.
-    ```
-    mysql_options(mysql, MYSQL_OPT_RECONNECT)       /* disable */
-    mysql_options(mysql, MYSQL_OPT_RECONNECT, "1")  /* enable */
+    options(db, OPT_PROTOCOL, PROTOCOL_SOCKET)
     ```
 
-- **MYSQL_OPT_READ_TIMEOUT** Specifies the timeout in seconds for reading packets from server. This
+- **OPT_RECONNECT** Enable or disable automatic reconnect.
+    ```
+    options(db, OPT_RECONNECT)       /* disable */
+    options(db, OPT_RECONNECT, "1")  /* enable */
+    ```
+
+- **OPT_READ_TIMEOUT** Specifies the timeout in seconds for reading packets from server. This
     value will be passed as an unsigned int.
     ```
-    mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, 5)
+    options(db, OPT_READ_TIMEOUT, 5)
     ```
 
-- **MYSQL_OPT_WRITE_TIMEOUT** Specifies the timeout in seconds for sending packets to server. This
+- **OPT_WRITE_TIMEOUT** Specifies the timeout in seconds for sending packets to server. This
     value will be passed as an unsigned int.
     ```
-    mysql_options(mysql, MYSQL_OPT_WRITE_TIMEOUT, 5)
+    options(db, OPT_WRITE_TIMEOUT, 5)
     ```
 
-- **MYSQL_READ_DEFAULT_FILE** Read options from named option file instead of *my.cnf*
+- **READ_DEFAULT_FILE** Read options from named option file instead of *my.cnf*
     ```
-    mysql_options(mysql, MYSQL_READ_DEFAULT_FILE, "./my_conf.cnf")
-    ```
-
-- **MYSQL_READ_DEFAULT_GROUP** Read options from the named group from my.cnf or the file specified
-    with *MYSQL_READ_DEFAULT_FILE*.
-    ```
-    mysql_options(mysql, MYSQL_READ_DEFAULT_GROUP, "my_section")
+    options(db, READ_DEFAULT_FILE, "./my_conf.cnf")
     ```
 
-- **MYSQL_REPORT_DATA_TRUNCATION** Enable or disable reporting data truncation errors for prepared
+- **READ_DEFAULT_GROUP** Read options from the named group from my.cnf or the file specified
+    with *READ_DEFAULT_FILE*.
+    ```
+    options(db, READ_DEFAULT_GROUP, "my_section")
+    ```
+
+- **REPORT_DATA_TRUNCATION** Enable or disable reporting data truncation errors for prepared
     statement.
     ```
-    mysql_options(mysql, MYSQL_REPORT_DATA_TRUNCATION)        /* disable */
-    mysql_options(mysql, MYSQL_REPORT_DATA_TRUNCATION, "1")   /* enable */
+    options(db, REPORT_DATA_TRUNCATION)        /* disable */
+    options(db, REPORT_DATA_TRUNCATION, "1")   /* enable */
     ```
 
-- **MYSQL_SET_CHARSET_NAME** Specify the default character set for the connection.
+- **SET_CHARSET_NAME** Specify the default character set for the connection.
     ```
-    mysql_options(mysql, MYSQL_SET_CHARSET_NAME, "utf8")
+    options(db, SET_CHARSET_NAME, "utf8")
     ```
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **option** the option you want to set. See description above.
 - **arg** The value for the option.
 """
-function _mysql_options(mysql::MYSQL, option::MYSQL_OPTION, arg::Ptr{Void})
-    option == MYSQL_PROGRESS_CALLBACK &&
-        error("Unsupported option: MYSQL_PROGRESS_CALLBACK")
+function _options(db::DB, option::OPTION, arg::Ptr{Void})
+    option == PROGRESS_CALLBACK &&
+        error("Unsupported option: PROGRESS_CALLBACK")
     ccall( (:mysql_options, mariadb_lib), Cint, (Ptr{Void}, Cint, Ptr{Void}),
-           mysql.ptr, option, arg)
+           db.ptr, option, arg)
 end
 
-mysql_options(mysql::MYSQL, option::MYSQL_OPTION) = _mysql_options(mysql, option, C_NULL)
-
-mysql_options(mysql::MYSQL, option::MYSQL_OPTION, arg::ByteString) =
-    _mysql_options(mysql, option, @str_2_c_str(arg))
-
-mysql_options(mysql::MYSQL, option::MYSQL_OPTION, arg::Int) =
-    _mysql_options(mysql, option, pointer(Cint[arg]))
-
-mysql_options(mysql::MYSQL, option::MYSQL_OPTION, arg::UInt) =
-    _mysql_optinos(mysql, option, pointer(Cuint[arg]))
-
-mysql_options(mysql::MYSQL, optino::MYSQL_OPTION, arg::MYSQL_PROTOCOL_TYPE) =
-    mysql_options(mysql, option, convert(Int, arg))
+options(db::DB, option::OPTION) = _options(db, option, C_NULL)
+options(db::DB, option::OPTION, arg::ByteString) = _options(db, option, @str_2_c_str(arg))
+options(db::DB, option::OPTION, arg::Int) = _options(db, option, pointer(Cint[arg]))
+options(db::DB, option::OPTION, arg::UInt) = _options(db, option, pointer(Cuint[arg]))
+options(db::DB, option::OPTION, arg::PROTOCOL_TYPE) =  _options(db, option, convert(Int, arg))
 
 """
 # Description
@@ -837,7 +822,7 @@ mysql_options(mysql::MYSQL, optino::MYSQL_OPTION, arg::MYSQL_PROTOCOL_TYPE) =
 Checks whether the connection to the server is working. If it has gone down, and global option
 reconnect is enabled an automatic reconnection is attempted.
 
-Returns MYSQL_OK on success, nonzero if an error occured.
+Returns DB_OK on success, nonzero if an error occured.
 
 This function can be used by clients that remain idle for a long while, to check whether the server
 has closed the connection and reconnect if necessary.
@@ -847,48 +832,48 @@ If a reconnect occurred the thread_id will change. Also resources bundled to the
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_ping(mysql::MYSQL) = ccall( (:mysql_ping, mariadb_lib), Cint, (Ptr{Void},), mysql.ptr)
+ping(db::DB) = ccall( (:mysql_ping, mariadb_lib), Cint, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
 Performs a statement pointed to by the null terminate string query against the database. Contrary to
-*mysql_real_query()*, *mysql_query()* is not binary safe.
+*real_query()*, *query()* is not binary safe.
 
-Returns MYSQL_OK on success, non zero on failure.
+Returns DB_OK on success, non zero on failure.
 
 For executing multi statements the statements within the null terminated string statements must be
 separated by a semicolon.
 
-If your statement contains binary data you should use *mysql_real_query()* or escape your data with
-*mysql_hex_string()*.
+If your statement contains binary data you should use *real_query()* or escape your data with
+*hex_string()*.
 
-To determine if a statement returned a result set use the function *mysql_num_fields()*.
+To determine if a statement returned a result set use the function *num_fields()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **query** a string containing the statement to be performed.
 """
-mysql_query(mysql::MYSQL, query::ByteString) =
-    ccall( (:mysql_query, mariadb_lib), Cint, (Ptr{Void}, Ptr{UInt8}), mysql.ptr, query)
+query(db::DB, query) =
+    ccall( (:mysql_query, mariadb_lib), Cint, (Ptr{Void}, Cstring), db.ptr, query)
 
 """
 # Description
 
-Establishes a connection to a database server. Returns a MYSQL handle or C_NULL if an error
+Establishes a connection to a database server. Returns a database handle or C_NULL if an error
 occurred.
 
-The password doesn't need to be encrypted before executing mysql_real_connect(). This will be
+The password doesn't need to be encrypted before executing real_connect(). This will be
 handled in the client server protocol.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()*.
+- **db** a database handle, identifier, which was previously allocated by *init()*.
 - **host** can be either a host name or an IP address. Passing the C_NULL value or the string "" or
     "localhost" to this parameter, the local host is assumed. When possible, pipes will be used
     instead of the TCP/IP protocol.
@@ -912,36 +897,35 @@ handled in the client server protocol.
         stored procedures or multi statements. This option will be automatically set if
         *CLIENT_MULTI_STATEMENTS* is set.
 """
-_mysql_real_connect(mysqlptr::Ptr{Void},
-                    host::Ptr{UInt8} = C_NULL,
-                    user::Ptr{UInt8} = C_NULL,
-                    passwd::Ptr{UInt8} = C_NULL,
-		    db::Ptr{UInt8} = C_NULL,
-                    port::UInt=UInt(0),
-                    unix_socket::Ptr{UInt8} = C_NULL,
-                    flags::UInt32=UInt32(0)) =
+_real_connect(dbptr::Ptr{Void},
+              host::Ptr{UInt8} = C_NULL,
+              user::Ptr{UInt8} = C_NULL,
+              passwd::Ptr{UInt8} = C_NULL,
+	      dbname::Ptr{UInt8} = C_NULL,
+              port::UInt=UInt(0),
+              unix_socket::Ptr{UInt8} = C_NULL,
+              flags::UInt32=UInt32(0)) =
     ccall( (:mysql_real_connect, mariadb_lib), Ptr{Void},
 	   (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8},
             Ptr{UInt8}, Cuint, Ptr{UInt8}, Culong),
-           mysqlptr, host, user,passwd, db, port, unix_socket,flags)
+           dbptr, host, user,passwd, dbname, port, unix_socket,flags)
 
-function mysql_real_connect(mysql::MYSQL, host::ByteString, user::ByteString;
-                            passwd::ByteString = "",
-		            db::ByteString = "",
-                            port::UInt = UInt(0),
-                            unix_socket::ByteString = "",
-                            flags::UInt32 = UInt32(0))
-    ret = _mysql_real_connect(mysql.ptr,
-                              @str_2_c_str(host),
-                              @str_2_c_str(user),
-                              @str_2_c_str(passwd),
-                              @str_2_c_str(db),
-                              port,
-                              @str_2_c_str(unix_socket),
-    		              flags)
-    ret != mysql.ptr && println("mysql_real_connect: $ret != $(mysql.ptr)")
-    mysql.ptr = ret
-    mysql
+function real_connect(db::DB, host::ByteString, user::ByteString;
+                      passwd::ByteString = "",
+		      dbname::ByteString = "",
+                      port::UInt = UInt(0),
+                      unix_socket::ByteString = "",
+                      flags::UInt32 = UInt32(0))
+    ret = _real_connect(db.ptr,
+                        @str_2_c_str(host),
+                        @str_2_c_str(user),
+                        @str_2_c_str(passwd),
+                        @str_2_c_str(dbname),
+                        port,
+                        @str_2_c_str(unix_socket),
+    		        flags)
+    db.ptr = ret
+    db
 end
 
 """
@@ -954,41 +938,40 @@ Returns the escaped string.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **from** the string which will be escaped
 """
-function mysql_real_escape_string(mysql::MYSQL, from::ByteString)
-    num_bytes = sizeof(from)
+function real_escape_string(db::DB, from::AbstractString)
+    num_bytes = length(from)
     out = Vector{UInt8}(num_bytes * 2 + 1)
     len = ccall( (:mysql_real_escape_string, mariadb_lib), Culong,
-                  (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Culong),
-                  mysql.ptr, out, from, num_bytes)
+                  (Ptr{Void}, Ptr{UInt8}, Cstring, Culong),
+                  db.ptr, out, from, num_bytes)
     r = range(1, Int64(len))
     return (bytestring(getindex(out,r)), len)
 end
 
 """
-**mysql_real_query()** is the binary safe function for performing a statement on the database
+**real_query()** is the binary safe function for performing a statement on the database
 server.
 
-Returns MYSQL_OK on success, otherwise non zero
+Returns DB_OK on success, otherwise non zero
 
-Contrary to the *mysql_query()* function, **mysql_real_query** is binary safe.
+Contrary to the *query()* function, **real_query** is binary safe.
 
-To determine if **mysql_real_query** returns a result set use the *mysql_num_fields()* function.
+To determine if **real_query** returns a result set use the *num_fields()* function.
 
 # Parameters
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **query** a string containing the statement to be performed.
 """
-mysql_real_query(mysql::MYSQL, query::Vector{UInt8}) =
+real_query(db::DB, query::Vector{UInt8}) =
     ccall( (:mysql_real_query, mariadb_lib), Cint, (Ptr{Void}, Ptr{UInt8}, Culong),
-           mysql.ptr, query, length(query))
+           db.ptr, query, length(query))
 
-mysql_real_query(mysql::MYSQL, query::ByteString) =
-    mysql_real_query(mysql, convert(Vector{UInt8}, query))
+real_query(db::DB, query::AbstractString) = real_query(db, bytestring(query).data)
 
 """
 # Description
@@ -1010,116 +993,117 @@ following:
 | REFRESH_READ_LOCK |                                                     |
 | REFRESH_FAST      |                                                     |
 
-Returns MYSQL_OK on success, otherwise non zero.
+Returns DB_OK on success, otherwise non zero.
 
 To combine different values in the options parameter use the OR operator '|'. The function
-*mysql_reload()* is an alias for *mysql_refresh()*.
+*reload()* is an alias for *refresh()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **options**  a bit masked composed integer. See above.
 """
-mysql_refresh(mysql::MYSQL, options::UInt32) =
-    ccall( (:mysql_refresh, mariadb_lib), Cchar, (Ptr{Void}, Cuint), mysql.ptr, options)
+refresh(db::DB, options::UInt32) =
+    ccall( (:mysql_refresh, mariadb_lib), Cchar, (Ptr{Void}, Cuint), db.ptr, options)
 
 """
 # Description
 
 Rolls back the current transaction for the database.
 
-Returns MYSQL_OK on success, nonzero if an error occurred.
+Returns DB_OK on success, nonzero if an error occurred.
 
-**mysql_rollback()** will not work as expected if autocommit mode was set or the storage engine does
+**rollback()** will not work as expected if autocommit mode was set or the storage engine does
 not support transactions.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_rollback(mysql::MYSQL) =
-    ccall( (:mysql_rollback, mariadb_lib), Cchar, (Ptr{Void},), mysql.ptr)
+rollback(db::DB) =
+    ccall( (:mysql_rollback, mariadb_lib), Cchar, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
 Positions the row cursor to an aribtrary row in a result set which was obtained by
-*mysql_store_result()*.
+*store_result()*.
 
 Returns the previous row offset.
 
-This function will **not** work if the result set was obtained by *mysql_use_result()*.
+This function will **not** work if the result set was obtained by *use_result()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
-- **offset** row offset. This value can be obtained either by *mysql_row_seek()* or
-    *mysql_row_tell()*
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
+- **offset** row offset. This value can be obtained either by *row_seek()* or
+    *row_tell()*
 """
-mysql_row_seek(result::MYSQL_RES, offset::MYSQL_ROW_OFFSET) =
-    MYSQL_ROW_OFFSET(ccall( (:mysql_row_seek, mariadb_lib), Ptr{Void},
+row_seek(result::DB_RES, offset::DB_ROW_OFFSET) =
+    DB_ROW_OFFSET(ccall( (:mysql_row_seek, mariadb_lib), Ptr{Void},
                             (Ptr{Void}, Ptr{Void}), result.ptr, offset.ptr))
 
 """
 # Description
 
 Returns the row offset of a result cursor. The returned offset value can be used to reposition the
-result cursor by calling *mysql_row_seek()*.
+result cursor by calling *row_seek()*.
 
-This function will not work if the result set was obtained by *mysql_use_result()*.
+This function will not work if the result set was obtained by *use_result()*.
 
 # Parameters
 
-- **result** a result set identifier returned by *mysql_store_result()* or *mysql_use_result()*.
+- **result** a result set identifier returned by *store_result()* or *use_result()*.
 """
-mysql_row_tell(result::MYSQL_RES) =
-    MYSQL_ROW_OFFSET(ccall( (:mysql_row_tell, mariadb_lib), Ptr{Void}, (Ptr{Void},), result.ptr))
+row_tell(result::DB_RES) =
+    DB_ROW_OFFSET(ccall( (:mysql_row_tell, mariadb_lib), Ptr{Void}, (Ptr{Void},), result.ptr))
 
 """
 # Description
 
 Selects a database as default.
 
-Returns MYSQL_OK on success, non-zero on failure.
+Returns DB_OK on success, non-zero on failure.
 
 The SQL command SELECT DATABASE() will return the name of the default database.
 
-The default database can also be set by the db parameter in mysql_real_connect().
+The default database can also be set by the db parameter in real_connect().
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **db** the default database name.
 """
-mysql_select_db(mysql::MYSQL, db::ByteString) =
-    ccall( (:mysql_select_db, mariadb_lib), Cint, (Ptr{Void}, Ptr{Void}), mysql.ptr, db)
+select_db(db::DB, dbname::AbstractString) =
+    ccall( (:mysql_select_db, mariadb_lib), Cint, (Ptr{Void}, Cstring), db.ptr, dbname)
 
 """
 # Description
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **query** the query
 """
-mysql_send_query(mysql::MYSQL, query::ByteString) =
+send_query(db::DB, query::ByteString) =
     ccall( (:mysql_send_query, mariadb_lib),
-           Cint, (Ptr{Void}, Ptr{Void}, Culong),
-           mysql.ptr, query, sizeof(query))
+           Cint, (Ptr{Void}, Cstring, Culong),
+           db.ptr, query, sizeof(query))
+send_query(db::DB, query::AbstractString) = send_query(db, bytestring(query))
 
 """
 # Description
 
 Sets the default character set for the current connection.
 
-Returns MYSQL_OK on success, non-zero on failure.
+Returns DB_OK on success, non-zero on failure.
 
-It's strongly recommended to use mysql_set_character_set() instead of SET NAMES ... since
-*mysql_real_escape_string()* might fail or deliver unexpected results.
+It's strongly recommended to use set_character_set() instead of SET NAMES ... since
+*real_escape_string()* might fail or deliver unexpected results.
 
 The client library supports the following character sets:
 
@@ -1166,13 +1150,13 @@ The client library supports the following character sets:
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **csname** character set name
 """
-mysql_set_character_set(mysql::MYSQL, csname::ByteString) =
-    ccall( (:mysql_set_character_set, mariadb_lib), Cint, (Ptr{Void}, Ptr{UInt8}),
-           mysql.ptr, csname)
+set_character_set(db::DB, csname::AbstractString) =
+    ccall( (:mysql_set_character_set, mariadb_lib), Cint, (Ptr{Void}, Cstring),
+           db.ptr, csname)
 
 """
 # Description
@@ -1181,17 +1165,17 @@ Server option, which can be one of the following values:
 
 | Option                            | Description                      |
 | --------------------------------- | -------------------------------- |
-| MYSQL_OPTION_MULTI_STATEMENTS_OFF | Disables multi statement support |
-| MYSQL_OPTION_MULTI_STATEMENTS_ON  | Enable multi statement support   |
+| OPTION_MULTI_STATEMENTS_OFF | Disables multi statement support |
+| OPTION_MULTI_STATEMENTS_ON  | Enable multi statement support   |
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **option** server option (see above)
 """
-mysql_set_server_option(mysql::MYSQL, option::MYSQL_SET_OPTION) =
-    ccall( (:mysql_set_server_option, mariadb_lib), Cint, (Ptr{Void}, Cint), mysql.ptr, option)
+set_server_option(db::DB, option::SET_OPTION) =
+    ccall( (:mysql_set_server_option, mariadb_lib), Cint, (Ptr{Void}, Cint), db.ptr, option)
 
 """
 # Description
@@ -1199,16 +1183,16 @@ mysql_set_server_option(mysql::MYSQL, option::MYSQL_SET_OPTION) =
 Sends a shutdown message to the server. To shutdown the database server, the user for the current
 connection must have SHUTDOWN privileges.
 
-Returns MYSQL_OK on success, non-zero on failure.
+Returns DB_OK on success, non-zero on failure.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **shutdown_level** currently only one shutdown level, **SHUTDOWN_DEFAULT** is supported.
 """
-mysql_shutdown(mysql::MYSQL, shutdown_level::MYSQL_SHUTDOWN_LEVEL) =
-    ccall( (:mysql_shutdown, mariadb_lib), Cint, (Ptr{Void}, Cint), mysql.ptr, shutdown_level)
+shutdown(db::DB, shutdown_level::SHUTDOWN_LEVEL) =
+    ccall( (:mysql_shutdown, mariadb_lib), Cint, (Ptr{Void}, Cint), db.ptr, shutdown_level)
 
 """
 # Description
@@ -1222,134 +1206,126 @@ can't be mapped will returned as value HY000.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_sqlstate(mysql::MYSQL) = bytestring(
-    ccall( (:mysql_sqlstate, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+sqlstate(db::DB) = bytestring(
+    ccall( (:mysql_sqlstate, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
 
 Used for establishing a secure SSL connection. It must be called before attempting to use
-*mysql_real_connect()*. SSL support must be enabled in the client library in order for the function
+*real_connect()*. SSL support must be enabled in the client library in order for the function
 to have any effect.
 
 "" or C_NULL can be used for an unused parameter.
 
-*mysql_real_connect()* will return an error if attempting to connect and SSL is incorrectly set up.
+*real_connect()* will return an error if attempting to connect and SSL is incorrectly set up.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 - **key** path to the key file.
 - **cert** path to the certificate file.
 - **ca** path to the certificate authority file.
 - **capath** path to the directory containing the trusted SSL CA certificates in PEM format.
 - **cipher** list of permitted ciphers to use for SSL encryption.
 """
-_mysql_ssl_set(mysql::MYSQL,
-               key::Ptr{UInt8}=C_NULL,
-               cert::Ptr{UInt8}=C_NULL,
-	       ca::Ptr{UInt8}=C_NULL,
-               capath::Ptr{UInt8}=C_NULL,
-               cipher::Ptr{UInt8}=C_NULL) =
+_ssl_set(db::DB,
+         key::Ptr{UInt8}=C_NULL,
+         cert::Ptr{UInt8}=C_NULL,
+	 ca::Ptr{UInt8}=C_NULL,
+         capath::Ptr{UInt8}=C_NULL,
+         cipher::Ptr{UInt8}=C_NULL) =
     ccall( (:mysql_ssl_set, mariadb_lib), Cchar,
 	   (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}),
-           mysql.ptr, key, cert, ca, capath, cipher)
+           db.ptr, key, cert, ca, capath, cipher)
 
-mysql_ssl_set(mysql::MYSQL,
-              key::ByteString,
-              cert::ByteString,
-              ca::ByteString,
-              capath::ByteString,
-              cipher::ByteString) =
-    _mysql_ssl_set(mysql,
-                   @str_2_c_str(key),
-                   @str_2_c_str(cert),
-                   @str_2_c_str(ca),
-                   @str_2_c_str(capath),
-                   @str_2_c_str(cipher))
+ssl_set(db::DB, key::ByteString, cert::ByteString, ca::ByteString, capath::ByteString,
+        cipher::ByteString) =
+    _ssl_set(db, @str_2_c_str(key), @str_2_c_str(cert), @str_2_c_str(ca), @str_2_c_str(capath),
+             @str_2_c_str(cipher))
 
 """
 # Description
 
-**mysql_stat()** returns a string with the current server status for uptime, threads, queries, open
+**stat()** returns a string with the current server status for uptime, threads, queries, open
 tables, flush tables and queries per second.
 
 For a complete list of other status variables, you have to use the SHOW STATUS SQL command.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_stat(mysql::MYSQL) = bytestring(
-    ccall( (:mysql_stat, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), mysql.ptr))
+stat(db::DB) = bytestring(
+    ccall( (:mysql_stat, mariadb_lib), Ptr{UInt8}, (Ptr{Void},), db.ptr))
 
 """
 # Description
 
 Returns a buffered resultset from the last executed query.
 
-**mysql_store_result()** returns C_NULL in case an error occured or if the query didn't return data
+**store_result()** returns C_NULL in case an error occured or if the query didn't return data
 (e.g. when executing an INSERT or UPDATE query).
 
-*mysql_field_count()* indicates if there will be a result set available.
+*field_count()* indicates if there will be a result set available.
 
-The memory allocated by **mysql_store_result()** needs to be released by calling the function
-*mysql_free_result()*.
+The memory allocated by **store_result()** needs to be released by calling the function
+*free_result()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_store_result(mysql::MYSQL) =
-    ccall( (:mysql_store_result, mariadb_lib), Ptr{Void}, (Ptr{Void},), mysql.ptr)
-
-"""
-# Description
-
-The **mysql_thread_end()** function needs to be called before a client thread ends. It will release
-thread specific memory, which was allocated by a previous mysql_thread_init() call.
-
-Unlike *mysql_thread_init()* **mysql_thread_end()** will not be invoked automatically if the thread
-ends. To avoid memory leaks *mysql_thread_end()* must be called explicitly.
-"""
-mysql_thread_end() = ccall( (:mysql_thread_end, mariadb_lib), Void, ())
+store_result(db::DB) =
+    ccall( (:mysql_store_result, mariadb_lib), Ptr{Void}, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
-The mysql_thread_id() function returns the thread id for the current connection.
+The **thread_end()** function needs to be called before a client thread ends. It will release
+thread specific memory, which was allocated by a previous thread_init() call.
 
-The current connection can be killed with *mysql_kill()*. If reconnect option is enabled the thread
+Unlike *thread_init()* **thread_end()** will not be invoked automatically if the thread
+ends. To avoid memory leaks *thread_end()* must be called explicitly.
+"""
+thread_end() = ccall( (:mysql_thread_end, mariadb_lib), Void, ())
+
+"""
+# Description
+
+The thread_id() function returns the thread id for the current connection.
+
+The current connection can be killed with *kill()*. If reconnect option is enabled the thread
 id might change if the client reconnects to the server.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_thread_id(mysql::MYSQL) =
-    ccall( (:mysql_thread_id, mariadb_lib), Culong, (Ptr{Void},), mysql.ptr)
+thread_id(db::DB) =
+    ccall( (:mysql_thread_id, mariadb_lib), Culong, (Ptr{Void},), db.ptr)
 
 """
 # Description
 
 Thread initialization for multi threaded clients. Multi threaded clients should call
-**mysql_thread_init()** at the beginning of the thread initialization to initialize thread specific
-client library variables. If **mysql_thread_init()** was not called explicitly, it will be called
-automatically by *mysql_init()* or *mysql_real_connect()*.
+**thread_init()** at the beginning of the thread initialization to initialize thread specific
+client library variables. If **thread_init()** was not called explicitly, it will be called
+automatically by *init()* or *real_connect()*.
 
-Returns MYSQL_OK if successful or 1 if an error occurred.
+Returns DB_OK if successful or 1 if an error occurred.
 
-Before a client thread ends the *mysql_thread_end()* function must be called to release memory -
+Before a client thread ends the *thread_end()* function must be called to release memory -
 otherwise the client library will report an error.
 """
-mysql_thread_init() = ccall( (:mysql_thread_init, mariadb_lib), Cchar, ())
+thread_init() = ccall( (:mysql_thread_init, mariadb_lib), Cchar, ())
 
 """
 # Description
@@ -1359,30 +1335,30 @@ library was compiled as thread safe otherwise zero.
 
 By default the mariadb client library is compiled as thread safe.
 """
-mysql_thread_safe() = ccall( (:mysql_thread_safe, mariadb_lib), Cint, ())
+thread_safe() = ccall( (:mysql_thread_safe, mariadb_lib), Cint, ())
 
 """
 # Description
 
 Used to initiate the retrieval of a result set from the last query executed using the
-*mysql_real_query()* function on the database connection. Either this or *the mysql_store_result()*
+*real_query()* function on the database connection. Either this or *the store_result()*
 function must be called before the results of a query can be retrieved, and one or the other must be
 called to prevent the next query on that database connection from failing.
 
 Returns an unbuffered result set or C_NULL if an error occurred.
 
-The **mysql_use_result()** function does not transfer the entire result set. Hence several functions
-like *mysql_num_rows()* or *mysql_data_seek()* cannot be used. **mysql_use_result()** will block the
+The **use_result()** function does not transfer the entire result set. Hence several functions
+like *num_rows()* or *data_seek()* cannot be used. **use_result()** will block the
 current connection until all result sets are retrieved or result set was released by
-*mysql_free_result()*.
+*free_result()*.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_use_result(mysql::MYSQL) =
-    MYSQL_RES(ccall( (:mysql_use_result, mariadb_lib), Ptr{Void}, (Ptr{Void},), mysql.ptr))
+use_result(db::DB) =
+    DB_RES(ccall( (:mysql_use_result, mariadb_lib), Ptr{Void}, (Ptr{Void},), db.ptr))
 
 """
 # Description
@@ -1395,26 +1371,8 @@ information check the server documentation.
 
 # Parameters
 
-- **mysql** a mysql handle, identifier, which was previously allocated by *mysql_init()* or
-  *mysql_real_connect()*.
+- **db** a database handle, identifier, which was previously allocated by *init()* or
+  *real_connect()*.
 """
-mysql_warning_count(mysql::MYSQL) =
-    ccall( (:mysql_warning_count, mariadb_lib), Cuint, (Ptr{Void},), mysql.ptr)
-
-
-export mysql_affected_rows, mysql_autocommit, mysql_change_user, mysql_character_set_name,
-       mysql_close, mysql_commit, mysql_data_seek, mysql_dump_debug_info, mysql_errno,
-       mysql_error, mysql_escape_string, mysql_fetch_field, mysql_fetch_fields,
-       mysql_fetch_field_direct, mysql_fetch_lengths, mysql_fetch_row, mysql_field_count,
-       mysql_field_seek, mysql_field_tell, mysql_free_result, mysql_get_character_set_info,
-       mysql_get_client_info, mysql_get_client_version, mysql_get_host_info,
-       mysql_get_proto_info, mysql_get_server_info, mysql_get_server_version,
-       mysql_get_ssl_cipher, mysql_hex_string, mysql_info, mysql_init, mysql_insert_id,
-       mysql_kill, mysql_library_end, mysql_library_init, mysql_more_results, mysql_next_result,
-       mysql_num_fields, mysql_num_rows, mysql_options, mysql_ping, mysql_query,
-       mysql_real_connect, mysql_real_escape_string, mysql_real_query, mysql_refresh,
-       mysql_rollback, mysql_row_seek, mysql_row_tell, mysql_select_db, mysql_send_query,
-       mysql_server_end, mysql_server_init, mysql_set_character_set, mysql_set_server_option,
-       mysql_shutdown, mysql_sqlstate, mysql_ssl_set, mysql_stat, mysql_store_result,
-       mysql_thread_end, mysql_thread_id, mysql_thread_init, mysql_thread_safe, mysql_use_result,
-       mysql_warning_count
+warning_count(db::DB) =
+    ccall( (:mysql_warning_count, mariadb_lib), Cuint, (Ptr{Void},), db.ptr)

--- a/src/mariadb/funcs.jl
+++ b/src/mariadb/funcs.jl
@@ -280,7 +280,7 @@ function fetch_row(result::DB_RES)
     row = Vector{Any}()
     ptr = ccall( (:mysql_fetch_row, mariadb_lib), Ptr{Ptr{UInt8}}, (Ptr{Void},), result.ptr)
     ptr == C_NULL &&
-        return row
+    return row
     fields = fetch_fields(result)
     lengths = fetch_lengths(result)
     for i in 1:length(fields)
@@ -291,7 +291,7 @@ function fetch_row(result::DB_RES)
               ? Void()
               : dbparse(fields[i].julia_type, pointer_to_array(colptr, lengths[i])))
     end
-    return row
+    row
 end
 
 """

--- a/src/mariadb/types.jl
+++ b/src/mariadb/types.jl
@@ -4,413 +4,309 @@
 # The Julia wrapper types are:
 # Copyright (c) 2015 Dynactionize NV
 
-export MYSQL, MYSQL_RES, MYSQL_ROW, MYSQL_FIELD_OFFSET, MYSQL_ROW_OFFSET
+export DB, DB_ROW, DB_ROW_OFFSET, DB_FIELD_OFFSET, DB_FIELD, DB_CHARSET_INFO, DB_TIME, DB_RES
+export DB_FIELD_TYPE, OPTION, PROTOCOL_TYPE, STATUS, SET_OPTION, SHUTDOWN_LEVEL
+import Base: show
 
-type MYSQL
+type DB
     ptr::Ptr{Void}
-    MYSQL(p) = (val = new(p) ; finalizer(val, mysql_close) ; val)
+    DB(p) = (val = new(p) ; finalizer(val, close) ; val)
 end
 
-type MYSQL_RES
+type DB_RES
     ptr::Ptr{Void}
-    MYSQL_RES(p) = (val = new(p) ; finalizer(val, mysql_free_result) ; val)
+    DB_RES(p) = (val = new(p) ; finalizer(val, free_result) ; val)
 end
 
-immutable MYSQL_ROW
-    data::Vector{UTF8String}
+immutable DB_ROW_OFFSET
+    ptr::Ptr{Void}
 end
 
-immutable MYSQL_FIELD_OFFSET
+immutable DB_FIELD_OFFSET
     off::UInt32
 end
 
-immutable MYSQL_ROW_OFFSET
-    ptr::Ptr{Void}
-end
+@enum(DB_FIELD_TYPE,
+    FT_DECIMAL,
+    FT_TINY,
+    FT_SHORT,
+    FT_LONG,
+    FT_FLOAT,
+    FT_DOUBLE,
+    FT_NULL,
+    FT_TIMESTAMP,
+    FT_LONGLONG,
+    FT_INT24,
+    FT_DATE,
+    FT_TIME,
+    FT_DATETIME,
+    FT_YEAR,
+    FT_NOWDATE,
+    FT_VARCHAR,
+    FT_BIT,
+    FT_TIMESTAMP2,
+    FT_DATETIME2,
+    FT_TIME2,
 
-immutable MYSQL_FIELD_TYPE
-    typ::UInt8
-end
+    FT_NEWDECIMAL = 246,
+    FT_ENUM,
+    FT_SET,
+    FT_TINY_BLOB,
+    FT_MEDIUM_BLOB,
+    FT_LONG_BLOB,
+    FT_BLOB,
+    FT_VAR_STRING,
+    FT_STRING,
+    FT_GEOMETRY)
 
-immutable MYSQL_FIELD_JULIA_TYPE
-    typ::DataType
-end
-
-export MYSQL_FIELD_TYPE
-export MYSQL_TYPE_DECIMAL, MYSQL_TYPE_TINY, MYSQL_TYPE_SHORT, MYSQL_TYPE_LONG, MYSQL_TYPE_FLOAT,
-       MYSQL_TYPE_DOUBLE, MYSQL_TYPE_NULL, MYSQL_TYPE_TIMESTAMP, MYSQL_TYPE_LONGLONG,
-       MYSQL_TYPE_INT24, MYSQL_TYPE_DATE, MYSQL_TYPE_TIME, MYSQL_TYPE_DATETIME, MYSQL_TYPE_YEAR,
-       MYSQL_TYPE_NOWDATE, MYSQL_TYPE_VARCHAR, MYSQL_TYPE_BIT, MYSQL_TYPE_TIMESTAMP2,
-       MYSQL_TYPE_DATETIME2, MYSQL_TYPE_TIME2, MYSQL_TYPE_NEWDECIMAL, MYSQL_TYPE_ENUM,
-       MYSQL_TYPE_SET, MYSQL_TYPE_TINY_BLOB, MYSQL_TYPE_MEDIUM_BLOB, MYSQL_TYPE_LONG_BLOB,
-       MYSQL_TYPE_BLOB, MYSQL_TYPE_VAR_STRING, MYSQL_TYPE_STRING, MYSQL_TYPE_GEOMETRY
-export MYSQL_TYPE_JULIA_DECIMAL, MYSQL_TYPE_JULIA_TIMESTAMP, MYSQL_TYPE_JULIA_DATE, 
-       MYSQL_TYPE_JULIA_TIME, MYSQL_TYPE_JULIA_DATETIME, MYSQL_TYPE_JULIA_YEAR, 
-       MYSQL_TYPE_JULIA_VARCHAR, MYSQL_TYPE_JULIA_CHAR, MYSQL_TYPE_JULIA_BIT, MYSQL_TYPE_JULIA_ENUM, 
-       MYSQL_TYPE_JULIA_SET, MYSQL_TYPE_JULIA_TINY_BLOB, MYSQL_TYPE_JULIA_MEDIUM_BLOB, 
-       MYSQL_TYPE_JULIA_LONG_BLOB, MYSQL_TYPE_JULIA_BLOB, MYSQL_TYPE_JULIA_TINY_TEXT,
-       MYSQL_TYPE_JULIA_MEDIUM_TEXT, MYSQL_TYPE_JULIA_LONG_TEXT, MYSQL_TYPE_JULIA_TEXT, 
-       MYSQL_TYPE_JULIA_VARBINARY, MYSQL_TYPE_JULIA_BINARY, MYSQL_TYPE_JULIA_GEOMETRY
-export MYSQL_CHAR_SET_BINARY
-
-const MYSQL_TYPE_DECIMAL        = MYSQL_FIELD_TYPE(0)
-const MYSQL_TYPE_TINY           = MYSQL_FIELD_TYPE(1)
-const MYSQL_TYPE_SHORT          = MYSQL_FIELD_TYPE(2)
-const MYSQL_TYPE_LONG           = MYSQL_FIELD_TYPE(3)
-const MYSQL_TYPE_FLOAT          = MYSQL_FIELD_TYPE(4)
-const MYSQL_TYPE_DOUBLE         = MYSQL_FIELD_TYPE(5)
-const MYSQL_TYPE_NULL           = MYSQL_FIELD_TYPE(6)
-const MYSQL_TYPE_TIMESTAMP      = MYSQL_FIELD_TYPE(7)
-const MYSQL_TYPE_LONGLONG       = MYSQL_FIELD_TYPE(8)
-const MYSQL_TYPE_INT24          = MYSQL_FIELD_TYPE(9)
-const MYSQL_TYPE_DATE           = MYSQL_FIELD_TYPE(10)
-const MYSQL_TYPE_TIME           = MYSQL_FIELD_TYPE(11)
-const MYSQL_TYPE_DATETIME       = MYSQL_FIELD_TYPE(12)
-const MYSQL_TYPE_YEAR           = MYSQL_FIELD_TYPE(13)
-const MYSQL_TYPE_NOWDATE        = MYSQL_FIELD_TYPE(14)
-const MYSQL_TYPE_VARCHAR        = MYSQL_FIELD_TYPE(15)
-const MYSQL_TYPE_BIT            = MYSQL_FIELD_TYPE(16)
-const MYSQL_TYPE_TIMESTAMP2     = MYSQL_FIELD_TYPE(17)
-const MYSQL_TYPE_DATETIME2      = MYSQL_FIELD_TYPE(18)
-const MYSQL_TYPE_TIME2          = MYSQL_FIELD_TYPE(19)
-const MYSQL_TYPE_NEWDECIMAL     = MYSQL_FIELD_TYPE(246)
-const MYSQL_TYPE_ENUM           = MYSQL_FIELD_TYPE(247)
-const MYSQL_TYPE_SET            = MYSQL_FIELD_TYPE(248)
-const MYSQL_TYPE_TINY_BLOB      = MYSQL_FIELD_TYPE(249)
-const MYSQL_TYPE_MEDIUM_BLOB    = MYSQL_FIELD_TYPE(250)
-const MYSQL_TYPE_LONG_BLOB      = MYSQL_FIELD_TYPE(251)
-const MYSQL_TYPE_BLOB           = MYSQL_FIELD_TYPE(252)
-const MYSQL_TYPE_VAR_STRING     = MYSQL_FIELD_TYPE(253)
-const MYSQL_TYPE_STRING         = MYSQL_FIELD_TYPE(254)
-const MYSQL_TYPE_GEOMETRY       = MYSQL_FIELD_TYPE(255)
-
-type MYSQL_TYPE_JULIA_DECIMAL
-    val::ByteString
-
-    MYSQL_TYPE_JULIA_DECIMAL(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_DECIMAL(val::Vector{UInt8}) = new(bytestring(val))
-end
-
-type MYSQL_TYPE_JULIA_TIMESTAMP
-    val::ByteString
+immutable JT_ERROR ; end
     
-    MYSQL_TYPE_JULIA_TIMESTAMP(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_TIMESTAMP(val::Vector{UInt8}) = new(bytestring(val))
+for typ in (:DECIMAL, :TIMESTAMP, :DATE, :TIME, :DATETIME, :YEAR)
+    nam = symbol("JT_", typ)
+    @eval immutable $nam ; val::ByteString ; end
+    @eval $(nam)(val::Vector{UInt8}) = $(nam)(bytestring(val))
+    @eval show(io::IO, val::$nam) = show(io, val.val)
+    @eval dbparse(::Type{$nam}, val::Vector{UInt8}) = $nam(bytestring(val))
 end
 
-type MYSQL_TYPE_JULIA_DATE
-    val::ByteString
+for typ in (:VARCHAR, :CHAR, :BIT, :ENUM, :SET, :GEOMETRY)
+    nam = symbol("JT_", typ)
+    @eval immutable $nam ; val::ByteString ; end
+    @eval show(io::IO, val::$nam) = show(io, val.val)
+    @eval dbparse(::Type{$nam}, val::Vector{UInt8}) = $nam(bytestring(val))
+end
+
+for typ in (:TINY_TEXT, :MEDIUM_TEXT, :LONG_TEXT, :TEXT)
+    nam = symbol("JT_", typ)
+    # Shouldn't this be ByteString?
+    @eval immutable $nam ; val::Vector{UInt8} ; end
+    @eval show(io::IO, val::$nam) = show(io, bytestring(val.val))
+    @eval dbparse(::Type{$nam}, val::Vector{UInt8}) = $nam(bytestring(val))
+end
     
-    MYSQL_TYPE_JULIA_DATE(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_DATE(val::Vector{UInt8}) = new(bytestring(val))
+for typ in (:TINY_BLOB, :MEDIUM_BLOB, :LONG_BLOB, :VARBINARY, :BINARY, :BLOB)
+    nam = symbol("JT_", typ)
+    @eval type $nam ; val::Vector{UInt8} ; end
+    @eval show(io::IO, val::$nam) = show(io, val.val)
+    @eval dbparse(::Type{$nam}, val::Vector{UInt8}) = $nam(val)
 end
 
-type MYSQL_TYPE_JULIA_TIME
-    val::ByteString
-    
-    MYSQL_TYPE_JULIA_TIME(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_TIME(val::Vector{UInt8}) = new(bytestring(val))
+export JT_TEXT_TYPES, JT_BINARY_TYPES
+const JT_TEXT_TYPES = (JT_DECIMAL, JT_TIMESTAMP, JT_DATE, JT_TIME, JT_DATETIME, JT_YEAR,
+                       JT_VARCHAR, JT_CHAR, JT_BIT, JT_ENUM, JT_SET, JT_GEOMETRY,
+                       JT_TINY_TEXT, JT_MEDIUM_TEXT, JT_LONG_TEXT, JT_TEXT)
+const JT_BINARY_TYPES = (JT_TINY_BLOB, JT_MEDIUM_BLOB, JT_LONG_BLOB,
+                         JT_VARBINARY, JT_BINARY, JT_BLOB)
+const JT_TYPES = Union{JT_TIMESTAMP, JT_VARCHAR, JT_CHAR, JT_BIT, JT_ENUM, JT_SET, JT_GEOMETRY,
+                       JT_TINY_TEXT, JT_MEDIUM_TEXT, JT_LONG_TEXT, JT_TEXT,
+		       JT_TINY_BLOB, JT_MEDIUM_BLOB, JT_LONG_BLOB,
+		       JT_VARBINARY, JT_BINARY, JT_BLOB}
+
+dbparse{T<:Number}(::Type{T}, val) = parse(T, bytestring(val))
+
+"""Get small index, 1..maxindex, for MYSQL types"""
+const offindex = -UInt(FT_NEWDECIMAL)+UInt(FT_TIME2)+2
+const maxindex = UInt(FT_GEOMETRY)+offindex
+
+function _typeindex(val::UInt32)
+    val <= UInt32(FT_TIME2) && return val+1
+    UInt32(FT_NEWDECIMAL) <= val <= UInt32(FT_GEOMETRY) && return val+offindex
+    UInt32(0) # Invalid number
 end
 
-type MYSQL_TYPE_JULIA_DATETIME
-    val::ByteString
-    
-    MYSQL_TYPE_JULIA_DATETIME(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_DATETIME(val::Vector{UInt8}) = new(bytestring(val))
-end
+_typeindex(ft::DB_FIELD_TYPE) = _typeindex(UInt32(ft))
 
-type MYSQL_TYPE_JULIA_YEAR
-    val::ByteString
-    
-    MYSQL_TYPE_JULIA_YEAR(val::ByteString) = new(val)
-    MYSQL_TYPE_JULIA_YEAR(val::Vector{UInt8}) = new(bytestring(val))
-end
+const typearray =
+#                  Signed        Signed       Unsigned      Unsigned
+#     Name         Text          Binary       Text          Binary
+    [("DECIMAL",   JT_DECIMAL,   JT_ERROR,    JT_DECIMAL,   JT_ERROR),
+     ("TINY",      Int8,         Int8,        UInt8,        UInt8),
+     ("SHORT",     Int16,        Int16,       UInt16,       UInt8),
+     ("LONG",      Int32,        Int32,       UInt32,       UInt32),
+     ("FLOAT",     Float32,      Float32,     Float32,      Float32),
+     ("DOUBLE",    Float64,      Float64,     Float64,      Float64),
+     ("NULL",      Void,         Void,        Void,         Void),
+     ("TIMESTAMP", JT_ERROR,     JT_ERROR,    JT_ERROR,     JT_TIMESTAMP),
+     ("LONGLONG",  UInt64,       UInt64,      UInt64,       UInt64),
+     ("INT24",     Int32,        Int32,       UInt32,       UInt32),
+     ("DATE",      JT_DATE,      JT_ERROR,    JT_DATE,      JT_ERROR),
+     ("TIME",      JT_TIME,      JT_ERROR,    JT_TIME,      JT_ERROR),
+     ("DATETIME",  JT_DATETIME,  JT_ERROR,    JT_DATETIME,  JT_ERROR),
+     ("YEAR",      JT_ERROR,	 JT_ERROR,    JT_YEAR,      JT_ERROR),
+     ("NOWDATE",   JT_ERROR,     JT_ERROR,    JT_ERROR,     JT_DATETIME),
+     ("VARCHAR",   JT_VARCHAR,   JT_VARBINARY,JT_VARCHAR,   JT_VARBINARY),
+     ("BIT",       JT_BIT,       JT_ERROR,    JT_BIT,       JT_ERROR),
+     ("TIMESTAMP2",JT_ERROR,     JT_ERROR,    JT_ERROR,     JT_TIMESTAMP),
+     ("DATETIME2", JT_DATETIME,  JT_ERROR,    JT_DATETIME,  JT_ERROR),
+     ("TIME2",     JT_TIME,      JT_ERROR,    JT_TIME,      JT_ERROR),
+     ("NEWDECIMAL",JT_DECIMAL,   JT_ERROR,    JT_DECIMAL,   JT_ERROR),
+     ("ENUM",      JT_ENUM,      JT_ERROR,    JT_ENUM,      JT_ERROR),
+     ("SET",       JT_SET,       JT_ERROR,    JT_SET,       JT_ERROR),
+     ("TINY_BLOB", JT_TINY_TEXT, JT_TINY_BLOB,JT_TINY_TEXT, JT_TINY_BLOB),
+     ("MEDIUM_BLOB",JT_MEDIUM_TEXT,JT_MEDIUM_BLOB,JT_MEDIUM_TEXT,JT_MEDIUM_BLOB),
+     ("LONG_BLOB", JT_LONG_TEXT, JT_LONG_BLOB,JT_LONG_TEXT, JT_LONG_BLOB),
+     ("BLOB",      JT_TEXT,      JT_BLOB,     JT_TEXT,      JT_BLOB),
+     ("VAR_STRING",JT_VARCHAR,   JT_VARBINARY,JT_VARCHAR,   JT_VARBINARY),
+     ("STRING",    JT_CHAR,      JT_BINARY,   JT_CHAR,      JT_BINARY),
+     ("GEOMETRY",  JT_GEOMETRY,  JT_ERROR,    JT_GEOMETRY,  JT_ERROR)]
 
-type MYSQL_TYPE_JULIA_VARCHAR
-    val::ByteString
-end
+const textarray =
+    ["DECIMAL",
+     "TINY",
+     "SHORT",
+     "LONG",
+     "FLOAT",
+     "DOUBLE",
+     "NULL",
+     "TIMESTAMP",
+     "LONGLONG",
+     "INT24",
+     "DATE",
+     "TIME",
+     "DATETIME",
+     "YEAR",
+     "NOWDATE",
+     "VARCHAR",
+     "BIT",
+     "TIMESTAMP2",
+     "DATETIME2",
+     "TIME2",
+     "NEWDECIMAL",
+     "ENUM",
+     "SET",
+     "TINY_TEXT",
+     "MEDIUM_TEXT",
+     "LONG_TEXT",
+     "TEXT",
+     "VARCHAR",
+     "CHAR",
+     "GEOMETRY"]
 
-type MYSQL_TYPE_JULIA_CHAR
-    val::ByteString
-end
+const CHAR_SET_BINARY    = 63
 
-type MYSQL_TYPE_JULIA_BIT
-    val::ByteString
-end
+const TIMESTAMP_NONE     = -2
+const TIMESTAMP_ERROR    = -1
+const TIMESTAMP_DATE     =  0
+const TIMESTAMP_DATETIME =  1
+const TIMESTAMP_TIME     =  2
 
-type MYSQL_TYPE_JULIA_ENUM
-    val::ByteString
-end
+@enum(OPTION,
+    CONNECT_TIMEOUT,
+    OPT_COMPRESS,
+    OPT_NAMED_PIPE,
+    INIT_COMMAND,
+    READ_DEFAULT_FILE,
+    READ_DEFAULT_GROUP,
+    SET_CHARSET_DIR,
+    SET_CHARSET_NAME,
+    OPT_LOCAL_INFILE,
+    OPT_PROTOCOL,
+    SHARED_MEMORY_BASE_NAME,
+    OPT_READ_TIMEOUT,
+    OPT_WRITE_TIMEOUT,
+    OPT_USE_RESULT,
+    OPT_USE_REMOTE_CONNECTION,
+    OPT_USE_EMBEDDED_CONNECTION,
+    OPT_GUESS_CONNECTION,
+    SET_CLIENT_IP,
+    SECURE_AUTH,
+    REPORT_DATA_TRUNCATION,
+    OPT_RECONNECT,
+    OPT_SSL_VERIFY_SERVER_CERT,
+    PLUGIN_DIR,
+    DEFAULT_AUTH,
+    ENABLE_CLEARTEXT_PLUGIN,
+    PROGRESS_CALLBACK       = 5999,
+    OPT_NONBLOCK            = 6000)
 
-type MYSQL_TYPE_JULIA_SET
-    val::ByteString
-end
+@enum(PROTOCOL_TYPE, DEFAULT, TCP, SOCKET, PIPE, MEMORY)
 
-type MYSQL_TYPE_JULIA_TINY_BLOB
-    val::Vector{UInt8}
-end
+@enum(STATUS, READY, GET_RESULT, USE_RESULT, STATEMENT_GET_RESULT)
 
-type MYSQL_TYPE_JULIA_MEDIUM_BLOB
-    val::Vector{UInt8}
-end
+@enum(SET_OPTION, MULTI_STATEMENT_ON, OPTION_MULTI_STATEMENT_OFF)
 
-type MYSQL_TYPE_JULIA_LONG_BLOB
-    val::Vector{UInt8}
-end
+const NO_MORE_RESULTS               = -1
 
-type MYSQL_TYPE_JULIA_BLOB
-    val::Vector{UInt8}
-end
+const SHUTDOWN_KILLABLE_CONNECT     = 0x01
+const SHUTDOWN_KILLABLE_TRANS       = 0x02
+const SHUTDOWN_KILLABLE_LOCK_TABLE  = 0x04
+const SHUTDOWN_KILLABLE_UPDATE      = 0x08
 
-type MYSQL_TYPE_JULIA_TINY_TEXT
-    val::Vector{UInt8}
-end
+@enum(SHUTDOWN_LEVEL,
+    WAIT_DEFAULT          = 0,
+    WAIT_CONNECTIONS      = SHUTDOWN_KILLABLE_CONNECT,
+    WAIT_TRANSACTIONS     = SHUTDOWN_KILLABLE_TRANS,
+    WAIT_UPDATES          = SHUTDOWN_KILLABLE_UPDATE,
+    WAIT_ALL_BUFFERS      = SHUTDOWN_KILLABLE_UPDATE<<1,
+    WAIT_CRITICAL_BUFFERS = (SHUTDOWN_KILLABLE_UPDATE<<1)+1)
 
-type MYSQL_TYPE_JULIA_MEDIUM_TEXT
-    val::Vector{UInt8}
-end
+const NOT_NULL_FLAG                 = 0x00000001
+const PRI_KEY_FLAG                  = 0x00000002
+const UNIQUE_KEY_FLAG               = 0x00000004
+const MULTIPLE_KEY_FLAG             = 0x00000008
+const BLOB_FLAG                     = 0x00000010
+const UNSIGNED_FLAG                 = 0x00000020
+const ZEROFILL_FLAG                 = 0x00000040
+const BINARY_FLAG                   = 0x00000080
+const ENUM_FLAG                     = 0x00000100
+const AUTO_INCREMENT_FLAG           = 0x00000200
+const TIMESTAMP_FLAG                = 0x00000400
+const SET_FLAG                      = 0x00000800
+const NO_DEFAULT_VALUE_FLAG         = 0x00001000
+const ON_UPDATE_NOW_FLAG            = 0x00002000
+const NUM_FLAG                      = 0x00004000
+const UNIQUE_FLAG                   = 0x00008000
+const BINCP_FLAG                    = 0x00010000
+const GET_FIXED_FIELDS_FLAG         = 0x00020000
+const FIELD_IN_PART_FUNC_FLAG       = 0x00040000
 
-type MYSQL_TYPE_JULIA_LONG_TEXT
-    val::Vector{UInt8}
-end
+const CLIENT_LONG_PASSWORD          = 0x00000001
+const CLIENT_FOUND_ROWS             = 0x00000002
+const CLIENT_LONG_FLAG              = 0x00000004
+const CLIENT_CONNECT_WITH_DB        = 0x00000008
+const CLIENT_NO_SCHEMA              = 0x00000010
+const CLIENT_COMPRESS               = 0x00000020
+const CLIENT_ODBC                   = 0x00000040
+const CLIENT_LOCAL_FILES            = 0x00000080
+const CLIENT_IGNORE_SPACE           = 0x00000100
+const CLIENT_PROTOCOL_41            = 0x00000200
+const CLIENT_INTERACTIVE            = 0x00000400
+const CLIENT_SSL                    = 0x00000800
+const CLIENT_IGNORE_SIGPIPE         = 0x00001000
+const CLIENT_TRANSACTIONS           = 0x00002000
+const CLIENT_RESERVED               = 0x00004000
+const CLIENT_SECURE_CONNECTION      = 0x00008000
+const CLIENT_MULTI_STATEMENTS       = 0x00010000
+const CLIENT_MULTI_RESULTS          = 0x00020000
+const CLIENT_PS_MULTI_RESULTS       = 0x00040000
+const CLIENT_PLUGIN_AUTH            = 0x00080000
+const CLIENT_PROGRESS               = 0x20000000
+const CLIENT_SSL_VERIFY_SERVER_CERT = 0x40000000
 
-type MYSQL_TYPE_JULIA_TEXT
-    val::Vector{UInt8}
-end
-
-type MYSQL_TYPE_JULIA_VARBINARY
-    val::Vector{UInt8}
-end
-
-type MYSQL_TYPE_JULIA_BINARY
-    val::Vector{UInt8}
-end
-
-type MYSQL_TYPE_JULIA_GEOMETRY
-    val::ByteString
-end
-
-#TODO add all charsets
-const MYSQL_CHAR_SET_BINARY              = 63
-    
-MYSG_TYPE_STRINGS = (
-    MYSQL_TYPE_TINY_BLOB,
-    MYSQL_TYPE_MEDIUM_BLOB,
-    MYSQL_TYPE_LONG_BLOB,
-    MYSQL_TYPE_BLOB,
-    MYSQL_TYPE_STRING,
-    MYSQL_TYPE_VAR_STRING)
-    
-export MYSQL_TIMESTAMP_TYPE
-export MYSQL_TIMESTAMP_NONE, MYSQL_TIMESTAMP_ERROR, MYSQL_TIMESTAMP_DATE,
-       MYSQL_TIMESTAMP_DATETIME, MYSQL_TIMESTAMP_TIME
-
-immutable MYSQL_TIMESTAMP_TYPE
-    typ::Int8
-end
-
-const MYSQL_TIMESTAMP_NONE      = MYSQL_TIMESTAMP_TYPE(-2)
-const MYSQL_TIMESTAMP_ERROR     = MYSQL_TIMESTAMP_TYPE(-1)
-const MYSQL_TIMESTAMP_DATE      = MYSQL_TIMESTAMP_TYPE(0)
-const MYSQL_TIMESTAMP_DATETIME  = MYSQL_TIMESTAMP_TYPE(1)
-const MYSQL_TIMESTAMP_TIME      = MYSQL_TIMESTAMP_TYPE(2)
-
-
-export MYSQL_OPTION
-export MYSQL_OPT_CONNECT_TIMEOUT, MYSQL_OPT_COMPRESS, MYSQL_OPT_NAMED_PIPE, MYSQL_INIT_COMMAND,
-       MYSQL_READ_DEFAULT_FILE, MYSQL_READ_DEFAULT_GROUP, MYSQL_SET_CHARSET_DIR,
-       MYSQL_SET_CHARSET_NAME, MYSQL_OPT_LOCAL_INFILE, MYSQL_OPT_PROTOCOL,
-       MYSQL_SHARED_MEMORY_BASE_NAME, MYSQL_OPT_READ_TIMEOUT, MYSQL_OPT_WRITE_TIMEOUT,
-       MYSQL_OPT_USE_RESULT, MYSQL_OPT_USE_REMOTE_CONNECTION, MYSQL_OPT_USE_EMBEDDED_CONNECTION,
-       MYSQL_OPT_GUESS_CONNECTION, MYSQL_SET_CLIENT_IP, MYSQL_SECURE_AUTH,
-       MYSQL_REPORT_DATA_TRUNCATION, MYSQL_OPT_RECONNECT, MYSQL_OPT_SSL_VERIFY_SERVER_CERT,
-       MYSQL_PLUGIN_DIR, MYSQL_DEFAULT_AUTH, MYSQL_ENABLE_CLEARTEXT_PLUGIN, MYSQL_PROGRESS_CALLBACK,
-       MYSQL_OPT_NONBLOCK
-
-immutable MYSQL_OPTION
-    opt::UInt16
-end
-
-const MYSQL_OPT_CONNECT_TIMEOUT         = MYSQL_OPTION(0)
-const MYSQL_OPT_COMPRESS                = MYSQL_OPTION(1)
-const MYSQL_OPT_NAMED_PIPE              = MYSQL_OPTION(2)
-const MYSQL_INIT_COMMAND                = MYSQL_OPTION(3)
-const MYSQL_READ_DEFAULT_FILE           = MYSQL_OPTION(4)
-const MYSQL_READ_DEFAULT_GROUP          = MYSQL_OPTION(5)
-const MYSQL_SET_CHARSET_DIR             = MYSQL_OPTION(6)
-const MYSQL_SET_CHARSET_NAME            = MYSQL_OPTION(7)
-const MYSQL_OPT_LOCAL_INFILE            = MYSQL_OPTION(8)
-const MYSQL_OPT_PROTOCOL                = MYSQL_OPTION(9)
-const MYSQL_SHARED_MEMORY_BASE_NAME     = MYSQL_OPTION(10)
-const MYSQL_OPT_READ_TIMEOUT            = MYSQL_OPTION(11)
-const MYSQL_OPT_WRITE_TIMEOUT           = MYSQL_OPTION(12)
-const MYSQL_OPT_USE_RESULT              = MYSQL_OPTION(13)
-const MYSQL_OPT_USE_REMOTE_CONNECTION   = MYSQL_OPTION(14)
-const MYSQL_OPT_USE_EMBEDDED_CONNECTION = MYSQL_OPTION(15)
-const MYSQL_OPT_GUESS_CONNECTION        = MYSQL_OPTION(16)
-const MYSQL_SET_CLIENT_IP               = MYSQL_OPTION(17)
-const MYSQL_SECURE_AUTH                 = MYSQL_OPTION(18)
-const MYSQL_REPORT_DATA_TRUNCATION      = MYSQL_OPTION(19)
-const MYSQL_OPT_RECONNECT               = MYSQL_OPTION(20)
-const MYSQL_OPT_SSL_VERIFY_SERVER_CERT  = MYSQL_OPTION(21)
-const MYSQL_PLUGIN_DIR                  = MYSQL_OPTION(22)
-const MYSQL_DEFAULT_AUTH                = MYSQL_OPTION(23)
-const MYSQL_ENABLE_CLEARTEXT_PLUGIN     = MYSQL_OPTION(24)
-const MYSQL_PROGRESS_CALLBACK           = MYSQL_OPTION(5999)
-const MYSQL_OPT_NONBLOCK                = MYSQL_OPTION(6000)
-
-export MYSQL_PROTOCOL_TYPE
-export MYSQL_PROTOCOL_DEFAULT, MYSQL_PROTOCOL_TCP, MYSQL_PROTOCOL_SOCKET, MYSQL_PROTOCOL_PIPE,
-       MYSQL_PROTOCOL_PIPE
-
-immutable MYSQL_PROTOCOL_TYPE
-    typ::UInt8
-end
-
-const MYSQL_PROTOCOL_DEFAULT    = MYSQL_PROTOCOL_TYPE(0)
-const MYSQL_PROTOCOL_TCP        = MYSQL_PROTOCOL_TYPE(1)
-const MYSQL_PROTOCOL_SOCKET     = MYSQL_PROTOCOL_TYPE(2)
-const MYSQL_PROTOCOL_PIPE       = MYSQL_PROTOCOL_TYPE(3)
-const MYSQL_PROTOCOL_MEMORY     = MYSQL_PROTOCOL_TYPE(4)
-
-
-export MYSQL_STATUS
-export MYSQL_STATUS_READY, MYSQL_STATUS_GET_RESULT, MYSQL_STATUS_USE_RESULT,
-       MYSQL_STATUS_STATEMENT_GET_RESULT
-
-immutable MYSQL_STATUS
-    status::UInt8
-end
-
-const MYSQL_STATUS_READY                = MYSQL_STATUS(0)
-const MYSQL_STATUS_GET_RESULT           = MYSQL_STATUS(1)
-const MYSQL_STATUS_USE_RESULT           = MYSQL_STATUS(2)
-const MYSQL_STATUS_STATEMENT_GET_RESULT = MYSQL_STATUS(3)
-
-export MYSQL_SET_OPTION
-export MYSQL_OPTION_MULTI_STATEMENT_ON, MYSQL_OPTION_MULTI_STATEMENT_OFF
-
-immutable MYSQL_SET_OPTION
-    status::UInt8
-end
-
-const MYSQL_OPTION_MULTI_STATEMENTS_ON  = MYSQL_SET_OPTION(0)
-const MYSQL_OPTION_MULTI_STATEMENTS_OFF = MYSQL_SET_OPTION(1)
-
-export MYSQL_NO_MORE_RESULTS
-
-const MYSQL_NO_MORE_RESULTS               = -1
-
-export MYSQL_SHUTDOWN_KILLABLE_CONNECT, MYSQL_SHUTDOWN_KILLABLE_TRANS,
-       MYSQL_SHUTDOWN_KILLABLE_LOCK_TABLE, MYSQL_SHUTDOWN_KILLABLE_UPDATE
-
-const MYSQL_SHUTDOWN_KILLABLE_CONNECT     = 0x01
-const MYSQL_SHUTDOWN_KILLABLE_TRANS       = 0x02
-const MYSQL_SHUTDOWN_KILLABLE_LOCK_TABLE  = 0x04
-const MYSQL_SHUTDOWN_KILLABLE_UPDATE      = 0x08
-
-export MYSQL_SHUTDOWN_LEVEL
-
-immutable MYSQL_SHUTDOWN_LEVEL
-    level::UInt8
-end
-
-const SHUTDOWN_DEFAULT               = MYSQL_SHUTDOWN_LEVEL(0)
-const SHUTDOWN_WAIT_CONNECTIONS      = MYSQL_SHUTDOWN_LEVEL(MYSQL_SHUTDOWN_KILLABLE_CONNECT)
-const SHUTDOWN_WAIT_TRANSACTIONS     = MYSQL_SHUTDOWN_LEVEL(MYSQL_SHUTDOWN_KILLABLE_TRANS)
-const SHUTDOWN_WAIT_UPDATES          = MYSQL_SHUTDOWN_LEVEL(MYSQL_SHUTDOWN_KILLABLE_UPDATE)
-const SHUTDOWN_WAIT_ALL_BUFFERS      = MYSQL_SHUTDOWN_LEVEL(MYSQL_SHUTDOWN_KILLABLE_UPDATE<<1)
-const SHUTDOWN_WAIT_CRITICAL_BUFFERS = MYSQL_SHUTDOWN_LEVEL((MYSQL_SHUTDOWN_KILLABLE_UPDATE<<1)+1)
-
-export NOT_NULL_FLAG, PRI_KEY_FLAG, UNIQUE_KEY_FLAG, MULTIPLE_KEY_FLAG, BLOB_FLAG, UNSIGNED_FLAG,
-       ZEROFILL_FLAG, BINARY_FLAG, ENUM_FLAG, AUTO_INCREMENT_FLAG, TIMESTAMP_FLAG, SET_FLAG,
-       NO_DEFAULT_VALUE_FLAG, ON_UPDATE_NOW_FLAG, NUM_FLAG, UNIQUE_FLAG, BINCP_FLAG,
-       GET_FIXED_FIELDS_FLAG, FIELD_IN_PART_FUNC_FLAG
-
-const NOT_NULL_FLAG                  = 0x00000001
-const PRI_KEY_FLAG                   = 0x00000002
-const UNIQUE_KEY_FLAG                = 0x00000004
-const MULTIPLE_KEY_FLAG              = 0x00000008
-const BLOB_FLAG                      = 0x00000010
-const UNSIGNED_FLAG                  = 0x00000020
-const ZEROFILL_FLAG                  = 0x00000040
-const BINARY_FLAG                    = 0x00000080
-const ENUM_FLAG                      = 0x00000100
-const AUTO_INCREMENT_FLAG            = 0x00000200
-const TIMESTAMP_FLAG                 = 0x00000400
-const SET_FLAG                       = 0x00000800
-const NO_DEFAULT_VALUE_FLAG          = 0x00001000
-const ON_UPDATE_NOW_FLAG             = 0x00002000
-const NUM_FLAG                       = 0x00004000
-const UNIQUE_FLAG                    = 0x00008000
-const BINCP_FLAG                     = 0x00010000
-const GET_FIXED_FIELDS_FLAG          = 0x00020000
-const FIELD_IN_PART_FUNC_FLAG        = 0x00040000
-
-
-export CLIENT_LONG_PASSWORD, CLIENT_FOUND_ROWS, CLIENT_LONG_FLAG, CLIENT_CONNECT_WITH_DB,
-       CLIENT_NO_SCHEMA, CLIENT_COMPRESS, CLIENT_ODBC, CLIENT_LOCAL_FILES, CLIENT_IGNORE_SPACE,
-       CLIENT_PROTOCOL_41, CLIENT_INTERACTIVE, CLIENT_SSL, CLIENT_IGNORE_SIGPIPE,
-       CLIENT_TRANSACTIONS, CLIENT_RESERVED, CLIENT_SECURE_CONNECTION, CLIENT_MULTI_STATEMENTS,
-       CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS, CLIENT_PLUGIN_AUTH, CLIENT_PROGRESS,
-       CLIENT_SSL_VERIFY_SERVER_CERT
-
-const CLIENT_LONG_PASSWORD           = 0x00000001
-const CLIENT_FOUND_ROWS              = 0x00000002
-const CLIENT_LONG_FLAG               = 0x00000004
-const CLIENT_CONNECT_WITH_DB         = 0x00000008
-const CLIENT_NO_SCHEMA               = 0x00000010
-const CLIENT_COMPRESS                = 0x00000020
-const CLIENT_ODBC                    = 0x00000040
-const CLIENT_LOCAL_FILES             = 0x00000080
-const CLIENT_IGNORE_SPACE            = 0x00000100
-const CLIENT_PROTOCOL_41             = 0x00000200
-const CLIENT_INTERACTIVE             = 0x00000400
-const CLIENT_SSL                     = 0x00000800
-const CLIENT_IGNORE_SIGPIPE          = 0x00001000
-const CLIENT_TRANSACTIONS            = 0x00002000
-const CLIENT_RESERVED                = 0x00004000
-const CLIENT_SECURE_CONNECTION       = 0x00008000
-const CLIENT_MULTI_STATEMENTS        = 0x00010000
-const CLIENT_MULTI_RESULTS           = 0x00020000
-const CLIENT_PS_MULTI_RESULTS        = 0x00040000
-const CLIENT_PLUGIN_AUTH             = 0x00080000
-const CLIENT_PROGRESS                = 0x20000000
-const CLIENT_SSL_VERIFY_SERVER_CERT  = 0x40000000
-
-
-export REFRESH_GRANT, REFRESH_LOG, REFRESH_TABLES, REFRESH_HOSTS, REFRESH_STATUS, REFRESH_THREADS,
-       REFRESH_SLAVE, REFRESH_MASTER, REFRESH_ERROR_LOG, REFRESH_ENGINE_LOG, REFRESH_BINARY_LOG,
-       REFRESH_RELAY_LOG, REFRESH_GENERAL_LOG, REFRESH_SLOW_LOG, REFRESH_READ_LOCK,
-       REFRESH_CHECKPOINT, REFRESH_QUERY_CACHE, REFRESH_QUERY_CACHE_FREE, REFRESH_DES_KEY_FILE,
-       REFRESH_USER_RESOURCES, REFRESH_TABLE_STATS, REFRESH_INDEX_STATS, REFRESH_USER_STATS,
-       REFRESH_FAST
-
-const REFRESH_GRANT                  = 0x00000001
-const REFRESH_LOG                    = 0x00000002
-const REFRESH_TABLES                 = 0x00000004
-const REFRESH_HOSTS                  = 0x00000008
-const REFRESH_STATUS                 = 0x00000010
-const REFRESH_THREADS                = 0x00000020
-const REFRESH_SLAVE                  = 0x00000040
-const REFRESH_MASTER                 = 0x00000080
-const REFRESH_ERROR_LOG              = 0x00000100
-const REFRESH_ENGINE_LOG             = 0x00000200
-const REFRESH_BINARY_LOG             = 0x00000400
-const REFRESH_RELAY_LOG              = 0x00000800
-const REFRESH_GENERAL_LOG            = 0x00001000
-const REFRESH_SLOW_LOG               = 0x00002000
-const REFRESH_READ_LOCK              = 0x00004000
-const REFRESH_CHECKPOINT             = 0x00008000
-const REFRESH_QUERY_CACHE            = 0x00010000
-const REFRESH_QUERY_CACHE_FREE       = 0x00020000
-const REFRESH_DES_KEY_FILE           = 0x00040000
-const REFRESH_USER_RESOURCES         = 0x00080000
-const REFRESH_TABLE_STATS            = 0x00100000
-const REFRESH_INDEX_STATS            = 0x00200000
-const REFRESH_USER_STATS             = 0x00400000
-const REFRESH_FAST                   = 0x80000000
-
+const REFRESH_GRANT                 = 0x00000001
+const REFRESH_LOG                   = 0x00000002
+const REFRESH_TABLES                = 0x00000004
+const REFRESH_HOSTS                 = 0x00000008
+const REFRESH_STATUS                = 0x00000010
+const REFRESH_THREADS               = 0x00000020
+const REFRESH_SLAVE                 = 0x00000040
+const REFRESH_MASTER                = 0x00000080
+const REFRESH_ERROR_LOG             = 0x00000100
+const REFRESH_ENGINE_LOG            = 0x00000200
+const REFRESH_BINARY_LOG            = 0x00000400
+const REFRESH_RELAY_LOG             = 0x00000800
+const REFRESH_GENERAL_LOG           = 0x00001000
+const REFRESH_SLOW_LOG              = 0x00002000
+const REFRESH_READ_LOCK             = 0x00004000
+const REFRESH_CHECKPOINT            = 0x00008000
+const REFRESH_QUERY_CACHE           = 0x00010000
+const REFRESH_QUERY_CACHE_FREE      = 0x00020000
+const REFRESH_DES_KEY_FILE          = 0x00040000
+const REFRESH_USER_RESOURCES        = 0x00080000
+const REFRESH_TABLE_STATS           = 0x00100000
+const REFRESH_INDEX_STATS           = 0x00200000
+const REFRESH_USER_STATS            = 0x00400000
+const REFRESH_FAST                  = 0x80000000
 
 macro c_str_2_str(c_str)
     return :($c_str == C_NULL ? "" : bytestring($c_str))
@@ -420,7 +316,7 @@ macro str_2_c_str(str)
     return :($str == "" ? Base.convert(Ptr{UInt8}, C_NULL) : pointer($str))
 end
 
-type _MYSQL_FIELD_
+type _DB_FIELD_
     name::Ptr{UInt8}
     org_name::Ptr{UInt8}
     table::Ptr{UInt8}
@@ -437,7 +333,7 @@ type _MYSQL_FIELD_
     table_length::UInt32
     org_table_length::UInt32
     db_length::UInt32
-    catalog_lenght::UInt32
+    catalog_length::UInt32
     def_length::UInt32
     flags::UInt32
     decimals::UInt32
@@ -445,12 +341,10 @@ type _MYSQL_FIELD_
     field_type::UInt32
     extension::Ptr{Void}
 end
-_MYSQL_FIELD_() = _MYSQL_FIELD_(C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL,
-                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, C_NULL)
+_DB_FIELD_() = _DB_FIELD_(C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL,
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, C_NULL)
 
-export MYSQL_FIELD
-
-type MYSQL_FIELD
+type DB_FIELD
     name::UTF8String
     org_name::UTF8String
     table::UTF8String
@@ -460,151 +354,49 @@ type MYSQL_FIELD
     def::UTF8String
     length::UInt
     max_length::UInt
-    flags::UInt
-    decimals::UInt
-    charsetnr::UInt
-    field_type::MYSQL_FIELD_TYPE
-    field_julia_type::DataType
+    flags::UInt32
+    decimals::UInt32
+    charsetnr::UInt32
+    field_type::DB_FIELD_TYPE
+    julia_type::DataType
+    type_index::UInt8
 end
 
-const BINARY_PARSE_TYPES = Union{
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    Float32,
-    Float64
-}
-    
-const BINARY_NO_PARSE_TYPES = Union{
-    MYSQL_TYPE_JULIA_TINY_BLOB,
-    MYSQL_TYPE_JULIA_MEDIUM_BLOB,
-    MYSQL_TYPE_JULIA_LONG_BLOB,  
-    MYSQL_TYPE_JULIA_BLOB, 
-    MYSQL_TYPE_JULIA_VARBINARY,
-    MYSQL_TYPE_JULIA_VARBINARY,
-    MYSQL_TYPE_JULIA_BINARY
-}
+map_sql_type(typ, csn, fla) =
+    typearray[typ][(csn == CHAR_SET_BINARY ? 3 : 2) + ((fla & UNSIGNED_FLAG != 0) ? 2 : 0)]
 
-const NO_BINARY_NO_PARSE_TYPES = Union{
-    MYSQL_TYPE_JULIA_TINY_TEXT,
-    MYSQL_TYPE_JULIA_MEDIUM_TEXT,
-    MYSQL_TYPE_JULIA_LONG_TEXT,  
-    MYSQL_TYPE_JULIA_TEXT, 
-    MYSQL_TYPE_JULIA_VARCHAR,
-    MYSQL_TYPE_JULIA_VARCHAR,
-    MYSQL_TYPE_JULIA_CHAR,
-    MYSQL_TYPE_JULIA_DECIMAL,
-    MYSQL_TYPE_JULIA_TIMESTAMP,    
-    MYSQL_TYPE_JULIA_DATE,
-    MYSQL_TYPE_JULIA_TIME,  
-    MYSQL_TYPE_JULIA_DATETIME,
-    MYSQL_TYPE_JULIA_YEAR,    
-    MYSQL_TYPE_JULIA_DATETIME,
-    MYSQL_TYPE_JULIA_VARCHAR,
-    MYSQL_TYPE_JULIA_BIT,
-    MYSQL_TYPE_JULIA_TIMESTAMP,  
-    MYSQL_TYPE_JULIA_DATETIME,
-    MYSQL_TYPE_JULIA_TIME,   
-    MYSQL_TYPE_JULIA_DECIMAL,
-    MYSQL_TYPE_JULIA_ENUM,
-    MYSQL_TYPE_JULIA_SET,
-    MYSQL_TYPE_JULIA_GEOMETRY
-}
-
-function __init__()
-    const global MYSQL_TYPES_JULIA_BINARY_UNSIGNED = Dict(
-        MYSQL_TYPE_TINY => UInt8,
-        MYSQL_TYPE_SHORT => UInt16,
-        MYSQL_TYPE_INT24 => UInt32,
-        MYSQL_TYPE_LONG => UInt32,    
-        MYSQL_TYPE_LONGLONG => UInt64,
-        MYSQL_TYPE_TIMESTAMP => MYSQL_TYPE_JULIA_TIMESTAMP,
-        MYSQL_TYPE_TIMESTAMP2 => MYSQL_TYPE_JULIA_TIMESTAMP,  
-        MYSQL_TYPE_NOWDATE => MYSQL_TYPE_JULIA_DATETIME,
-        MYSQL_TYPE_YEAR => MYSQL_TYPE_JULIA_YEAR
-    )
-
-    const global MYSQL_TYPES_JULIA_BINARY_SIGNED = Dict(
-        MYSQL_TYPE_TINY => Int8,
-        MYSQL_TYPE_SHORT => Int16,
-        MYSQL_TYPE_INT24 => Int32,
-        MYSQL_TYPE_LONG => Int32,    
-        MYSQL_TYPE_LONGLONG => Int64,
-        MYSQL_TYPE_FLOAT => Float32,
-        MYSQL_TYPE_DOUBLE => Float64, 
-        MYSQL_TYPE_TINY_BLOB => MYSQL_TYPE_JULIA_TINY_BLOB,
-        MYSQL_TYPE_MEDIUM_BLOB => MYSQL_TYPE_JULIA_MEDIUM_BLOB,
-        MYSQL_TYPE_LONG_BLOB => MYSQL_TYPE_JULIA_LONG_BLOB,  
-        MYSQL_TYPE_BLOB => MYSQL_TYPE_JULIA_BLOB, 
-        MYSQL_TYPE_VAR_STRING => MYSQL_TYPE_JULIA_VARBINARY,
-        MYSQL_TYPE_VARCHAR => MYSQL_TYPE_JULIA_VARBINARY,
-        MYSQL_TYPE_STRING => MYSQL_TYPE_JULIA_BINARY
-    )
-
-    const global MYSQL_TYPES_JULIA_NO_BINARY = Dict(
-        MYSQL_TYPE_TINY_BLOB => MYSQL_TYPE_JULIA_TINY_TEXT,
-        MYSQL_TYPE_MEDIUM_BLOB => MYSQL_TYPE_JULIA_MEDIUM_TEXT,
-        MYSQL_TYPE_LONG_BLOB => MYSQL_TYPE_JULIA_LONG_TEXT,  
-        MYSQL_TYPE_BLOB => MYSQL_TYPE_JULIA_TEXT, 
-        MYSQL_TYPE_VAR_STRING => MYSQL_TYPE_JULIA_VARCHAR,
-        MYSQL_TYPE_VARCHAR => MYSQL_TYPE_JULIA_VARCHAR,
-        MYSQL_TYPE_STRING => MYSQL_TYPE_JULIA_CHAR,
-        MYSQL_TYPE_DECIMAL => MYSQL_TYPE_JULIA_DECIMAL,
-        MYSQL_TYPE_NEWDECIMAL => MYSQL_TYPE_JULIA_DECIMAL,
-        MYSQL_TYPE_NULL => Void,
-        MYSQL_TYPE_DATE => MYSQL_TYPE_JULIA_DATE,
-        MYSQL_TYPE_TIME => MYSQL_TYPE_JULIA_TIME,  
-        MYSQL_TYPE_DATETIME => MYSQL_TYPE_JULIA_DATETIME,
-        MYSQL_TYPE_VAR_STRING => MYSQL_TYPE_JULIA_VARCHAR,
-        MYSQL_TYPE_VARCHAR => MYSQL_TYPE_JULIA_VARCHAR,
-        MYSQL_TYPE_BIT => MYSQL_TYPE_JULIA_BIT,
-        MYSQL_TYPE_DATETIME2 => MYSQL_TYPE_JULIA_DATETIME,
-        MYSQL_TYPE_TIME2 => MYSQL_TYPE_JULIA_TIME,   
-        MYSQL_TYPE_NEWDECIMAL => MYSQL_TYPE_JULIA_DECIMAL,
-        MYSQL_TYPE_ENUM => MYSQL_TYPE_JULIA_ENUM,
-        MYSQL_TYPE_SET => MYSQL_TYPE_JULIA_SET,
-        MYSQL_TYPE_GEOMETRY => MYSQL_TYPE_JULIA_GEOMETRY
-    ) 
-end
-
-function map_sql_type(typ, csn, fla)
-    if csn == MYSQL_CHAR_SET_BINARY
-        if fla & UNSIGNED_FLAG == UNSIGNED_FLAG
-            return MYSQL_TYPES_JULIA_BINARY_UNSIGNED[MYSQL_FIELD_TYPE(typ)]
-        end
-        if haskey(MYSQL_TYPES_JULIA_BINARY_SIGNED, MYSQL_FIELD_TYPE(typ))
-            return MYSQL_TYPES_JULIA_BINARY_SIGNED[MYSQL_FIELD_TYPE(typ)]
-        end
+function db_type_name(field::DB_FIELD)
+    typ = typearray[field.type_index]
+    if typ[2] != typ[4] && (field.flags & UNSIGNED_FLAG) != 0
+        string(typ[1]," UNSIGNED")
+    elseif field.charsetnr == CHAR_SET_BINARY
+        typ[1]
+    else
+        textarray[field.type_index]
     end
-    return MYSQL_TYPES_JULIA_NO_BINARY[MYSQL_FIELD_TYPE(typ)]
-end   
-
-MYSQL_FIELD() = MYSQL_FIELD("", "", "", "", "", 0, 0, 0, 0, 0, Void)
-function MYSQL_FIELD(c_mysql_field::_MYSQL_FIELD_)
-    MYSQL_FIELD(
-        @c_str_2_str(c_mysql_field.name),
-        @c_str_2_str(c_mysql_field.org_name),
-        @c_str_2_str(c_mysql_field.table),
-        @c_str_2_str(c_mysql_field.org_table),
-        @c_str_2_str(c_mysql_field.db),
-        @c_str_2_str(c_mysql_field.catalog),
-        @c_str_2_str(c_mysql_field.def),
-        c_mysql_field.length,
-        c_mysql_field.max_length,
-        c_mysql_field.flags,
-        c_mysql_field.decimals,
-        c_mysql_field.charsetnr,
-        MYSQL_FIELD_TYPE(c_mysql_field.field_type),
-        map_sql_type(c_mysql_field.field_type, c_mysql_field.charsetnr, c_mysql_field.flags)
-    )
 end
 
-type _MY_CHARSET_INFO_
+DB_FIELD() = DB_FIELD("", "", "", "", "", 0, 0, 0, 0, 0, Void)
+function DB_FIELD(c_db_field::_DB_FIELD_)
+    index = _typeindex(c_db_field.field_type)
+    DB_FIELD(@c_str_2_str(c_db_field.name),
+             @c_str_2_str(c_db_field.org_name),
+             @c_str_2_str(c_db_field.table),
+             @c_str_2_str(c_db_field.org_table),
+             @c_str_2_str(c_db_field.db),
+             @c_str_2_str(c_db_field.catalog),
+             @c_str_2_str(c_db_field.def),
+             c_db_field.length,
+             c_db_field.max_length,
+             c_db_field.flags,
+             c_db_field.decimals,
+             c_db_field.charsetnr,
+             DB_FIELD_TYPE(c_db_field.field_type),
+    	     map_sql_type(index, c_db_field.charsetnr, c_db_field.flags),
+    	     index)   
+end
+
+type _DB_CHARSET_INFO_
     number::UInt32
     state::UInt32
     csname::Ptr{UInt8}
@@ -614,11 +406,9 @@ type _MY_CHARSET_INFO_
     mbminlen::UInt32
     mbmaxlen::UInt32
 end
-_MY_CHARSET_INFO_() = _MY_CHARSET_INFO_(0, 0, C_NULL, C_NULL, C_NULL, C_NULL, 0, 0)
+_DB_CHARSET_INFO_() = _DB_CHARSET_INFO_(0, 0, C_NULL, C_NULL, C_NULL, C_NULL, 0, 0)
 
-export MY_CHARSET_INFO
-
-type MY_CHARSET_INFO
+type DB_CHARSET_INFO
     number::UInt
     state::UInt
     csname::UTF8String
@@ -628,9 +418,10 @@ type MY_CHARSET_INFO
     mbminlen::UInt
     mbmaxlen::UInt
 end
-MY_CHARSET_INFO() = MY_CHARSET_INFO(0, 0, "", "", "", "", 0, 0)
-function MY_CHARSET_INFO(c_charset_info::_MY_CHARSET_INFO_)
-    MY_CHARSET_INFO(
+
+DB_CHARSET_INFO() = DB_CHARSET_INFO(0, 0, "", "", "", "", 0, 0)
+function DB_CHARSET_INFO(c_charset_info::_DB_CHARSET_INFO_)
+    DB_CHARSET_INFO(
         c_charset_info.number,
         c_charset_info.state,
         @c_str_2_str(c_charset_info.csname),
@@ -642,10 +433,7 @@ function MY_CHARSET_INFO(c_charset_info::_MY_CHARSET_INFO_)
     )
 end
 
-
-export MYSQL_TIME
-
-type MYSQL_TIME
+type DB_TIME
     year::UInt32
     month::UInt32
     day::UInt32
@@ -655,5 +443,5 @@ type MYSQL_TIME
     @windows_only second_part::UInt32
     @unix_only second_part::UInt
     neg::Int8
-    time_type::MYSQL_TIMESTAMP_TYPE
+    time_type::Int8
 end

--- a/src/mariadb/types.jl
+++ b/src/mariadb/types.jl
@@ -26,38 +26,15 @@ immutable DB_FIELD_OFFSET
     off::UInt32
 end
 
-@enum(DB_FIELD_TYPE,
-    FT_DECIMAL,
-    FT_TINY,
-    FT_SHORT,
-    FT_LONG,
-    FT_FLOAT,
-    FT_DOUBLE,
-    FT_NULL,
-    FT_TIMESTAMP,
-    FT_LONGLONG,
-    FT_INT24,
-    FT_DATE,
-    FT_TIME,
-    FT_DATETIME,
-    FT_YEAR,
-    FT_NOWDATE,
-    FT_VARCHAR,
-    FT_BIT,
-    FT_TIMESTAMP2,
-    FT_DATETIME2,
-    FT_TIME2,
+typealias DB_ROW Vector{Any}
 
-    FT_NEWDECIMAL = 246,
-    FT_ENUM,
-    FT_SET,
-    FT_TINY_BLOB,
-    FT_MEDIUM_BLOB,
-    FT_LONG_BLOB,
-    FT_BLOB,
-    FT_VAR_STRING,
-    FT_STRING,
-    FT_GEOMETRY)
+@enum(DB_FIELD_TYPE,
+      FT_DECIMAL, FT_TINY, FT_SHORT, FT_LONG, FT_FLOAT, FT_DOUBLE, FT_NULL, FT_TIMESTAMP,
+      FT_LONGLONG, FT_INT24, FT_DATE, FT_TIME, FT_DATETIME, FT_YEAR, FT_NOWDATE, FT_VARCHAR,
+      FT_BIT, FT_TIMESTAMP2, FT_DATETIME2, FT_TIME2,
+
+      FT_NEWDECIMAL = 246, FT_ENUM, FT_SET, FT_TINY_BLOB, FT_MEDIUM_BLOB, FT_LONG_BLOB, FT_BLOB,
+      FT_VAR_STRING, FT_STRING, FT_GEOMETRY)
 
 immutable JT_ERROR ; end
     
@@ -100,7 +77,7 @@ _typeindex(ft::DB_FIELD_TYPE) = _typeindex(UInt32(ft))
 
 macro jtyptxt(nam)
     :( ($(string(nam)), $(string(nam)), "", "",
-        $(symbol("JT_",nam)), $(symbol("JT_",nam)), JT_ERROR, JT_ERROR) )
+        $(symbol(string("JT_",nam))), $(symbol(string("JT_",nam))), JT_ERROR, JT_ERROR) )
 end
 macro jtypnum(nam,st,ut)
     :( ($(string(nam)), $(string(nam," UNSIGNED")),$(string(nam)), $(string(nam," UNSIGNED")),
@@ -108,48 +85,48 @@ macro jtypnum(nam,st,ut)
 end
 macro jtypren(nam,typ)
     :( ($(string(nam)), $(string(nam)), "", "",
-        $(symbol("JT_",typ)), $(symbol("JT_",typ)), JT_ERROR, JT_ERROR) )
+        $(symbol(string("JT_",typ))), $(symbol(string("JT_",typ))), JT_ERROR, JT_ERROR) )
 end
 macro jtypstr(t1,t2)
     :( ($(string(t1)), $(string(t1)), $(string(t2)), $(string(t2)),
-        $(symbol("JT_",t1)), $(symbol("JT_",t1)), $(symbol("JT_",t2)), $(symbol("JT_",t2))) )
+        $(symbol(string("JT_",t1))), $(symbol(string("JT_",t1))), $(symbol(string("JT_",t2))), $(symbol(string("JT_",t2)))) )
 end
 
 const typearray =
 #     Signed        UnSigned     Signed        Unsigned
 #     Text          Text         Binary        Binary
-    [@jtyptxt(:DECIMAL),
-     @jtypnum(:TINY,     Int8,    UInt8),
-     @jtypnum(:SHORT,    Int16,   UInt16),
-     @jtypnum(:LONG,     Int32,   UInt32),
-     @jtypnum(:FLOAT,    Float32, Float32),
-     @jtypnum(:DOUBLE,   Float64, Float64),
+    [@jtyptxt(DECIMAL),
+     @jtypnum(TINY,     Int8,    UInt8),
+     @jtypnum(SHORT,    Int16,   UInt16),
+     @jtypnum(LONG,     Int32,   UInt32),
+     @jtypnum(FLOAT,    Float32, Float32),
+     @jtypnum(DOUBLE,   Float64, Float64),
      ("NULL","NULL","NULL","NULL",Void,Void,Void,Void),
      ("","","","TIMESTAMP",JT_ERROR,JT_ERROR,JT_ERROR,JT_TIMESTAMP),
-     @jtypnum(:LONGLONG, Int64,   UInt64),
-     @jtypnum(:INT24,    Int32,   UInt32),
-     @jtyptxt(:DATE),
-     @jtyptxt(:TIME),
-     @jtyptxt(:DATETIME),
+     @jtypnum(LONGLONG, Int64,   UInt64),
+     @jtypnum(INT24,    Int32,   UInt32),
+     @jtyptxt(DATE),
+     @jtyptxt(TIME),
+     @jtyptxt(DATETIME),
      ("","YEAR","","",JT_ERROR,JT_YEAR,JT_ERROR,JT_ERROR),
      ("","","","NOWDATE",JT_ERROR,JT_ERROR,JT_ERROR,JT_TIMESTAMP),
-     @jtypstr(:VARCHAR,:VARBINARY),
-     @jtyptxt(:BIT),
+     @jtypstr(VARCHAR,VARBINARY),
+     @jtyptxt(BIT),
      ("","","","TIMESTAMP2",JT_ERROR,JT_ERROR,JT_ERROR,JT_TIMESTAMP),
-     @jtypren(:DATETIME2,  :DATETIME),
-     @jtypren(:TIME2,      :TIME),
-     @jtypren(:NEWDECIMAL, :DECIMAL),
-     @jtyptxt(:ENUM),
-     @jtyptxt(:SET),
-     @jtypstr(:TINY_TEXT,:TINY_BLOB),
-     @jtypstr(:MEDIUM_TEXT,:MEDIUM_BLOB),
-     @jtypstr(:LONG_TEXT,:LONG_BLOB),
-     @jtypstr(:TEXT,:BLOB),
+     @jtypren(DATETIME2,  DATETIME),
+     @jtypren(TIME2,      TIME),
+     @jtypren(NEWDECIMAL, DECIMAL),
+     @jtyptxt(ENUM),
+     @jtyptxt(SET),
+     @jtypstr(TINY_TEXT,TINY_BLOB),
+     @jtypstr(MEDIUM_TEXT,MEDIUM_BLOB),
+     @jtypstr(LONG_TEXT,LONG_BLOB),
+     @jtypstr(TEXT,BLOB),
      ("VAR_STRING","VAR_STRING","VARBINARY","VARBINARY",
       JT_VARCHAR,JT_VARCHAR,JT_VARBINARY,JT_VARBINARY),
      ("STRING","STRING","BINARY","BINARY",
       JT_CHAR,JT_CHAR,JT_BINARY,JT_BINARY),
-     @jtyptxt(:GEOMETRY))]
+     @jtyptxt(GEOMETRY)]
 
 const CHAR_SET_BINARY    = 63
 
@@ -160,39 +137,20 @@ const TIMESTAMP_DATETIME =  1
 const TIMESTAMP_TIME     =  2
 
 @enum(OPTION,
-    CONNECT_TIMEOUT,
-    OPT_COMPRESS,
-    OPT_NAMED_PIPE,
-    INIT_COMMAND,
-    READ_DEFAULT_FILE,
-    READ_DEFAULT_GROUP,
-    SET_CHARSET_DIR,
-    SET_CHARSET_NAME,
-    OPT_LOCAL_INFILE,
-    OPT_PROTOCOL,
-    SHARED_MEMORY_BASE_NAME,
-    OPT_READ_TIMEOUT,
-    OPT_WRITE_TIMEOUT,
-    OPT_USE_RESULT,
-    OPT_USE_REMOTE_CONNECTION,
-    OPT_USE_EMBEDDED_CONNECTION,
-    OPT_GUESS_CONNECTION,
-    SET_CLIENT_IP,
-    SECURE_AUTH,
-    REPORT_DATA_TRUNCATION,
-    OPT_RECONNECT,
-    OPT_SSL_VERIFY_SERVER_CERT,
-    PLUGIN_DIR,
-    DEFAULT_AUTH,
-    ENABLE_CLEARTEXT_PLUGIN,
-    PROGRESS_CALLBACK       = 5999,
-    OPT_NONBLOCK            = 6000)
+      OPT_CONNECT_TIMEOUT, OPT_COMPRESS, OPT_NAMED_PIPE, INIT_COMMAND, READ_DEFAULT_FILE,
+      READ_DEFAULT_GROUP, SET_CHARSET_DIR, SET_CHARSET_NAME, OPT_LOCAL_INFILE, OPT_PROTOCOL,
+      SHARED_MEMORY_BASE_NAME, OPT_READ_TIMEOUT, OPT_WRITE_TIMEOUT, OPT_USE_RESULT,
+      OPT_USE_REMOTE_CONNECTION, OPT_USE_EMBEDDED_CONNECTION, OPT_GUESS_CONNECTION, SET_CLIENT_IP,
+      SECURE_AUTH, REPORT_DATA_TRUNCATION, OPT_RECONNECT, OPT_SSL_VERIFY_SERVER_CERT, PLUGIN_DIR,
+      DEFAULT_AUTH, ENABLE_CLEARTEXT_PLUGIN,
+      PROGRESS_CALLBACK       = 5999,
+      OPT_NONBLOCK            = 6000)
 
 @enum(PROTOCOL_TYPE, DEFAULT, TCP, SOCKET, PIPE, MEMORY)
 
 @enum(STATUS, READY, GET_RESULT, USE_RESULT, STATEMENT_GET_RESULT)
 
-@enum(SET_OPTION, MULTI_STATEMENT_ON, OPTION_MULTI_STATEMENT_OFF)
+@enum(SET_OPTION, MULTI_STATEMENT_ON, MULTI_STATEMENT_OFF)
 
 const NO_MORE_RESULTS               = -1
 
@@ -209,73 +167,73 @@ const SHUTDOWN_KILLABLE_UPDATE      = 0x08
     WAIT_ALL_BUFFERS      = SHUTDOWN_KILLABLE_UPDATE<<1,
     WAIT_CRITICAL_BUFFERS = (SHUTDOWN_KILLABLE_UPDATE<<1)+1)
 
-const NOT_NULL_FLAG                 = 0x00000001
-const PRI_KEY_FLAG                  = 0x00000002
-const UNIQUE_KEY_FLAG               = 0x00000004
-const MULTIPLE_KEY_FLAG             = 0x00000008
-const BLOB_FLAG                     = 0x00000010
-const UNSIGNED_FLAG                 = 0x00000020
-const ZEROFILL_FLAG                 = 0x00000040
-const BINARY_FLAG                   = 0x00000080
-const ENUM_FLAG                     = 0x00000100
-const AUTO_INCREMENT_FLAG           = 0x00000200
-const TIMESTAMP_FLAG                = 0x00000400
-const SET_FLAG                      = 0x00000800
-const NO_DEFAULT_VALUE_FLAG         = 0x00001000
-const ON_UPDATE_NOW_FLAG            = 0x00002000
-const NUM_FLAG                      = 0x00004000
-const UNIQUE_FLAG                   = 0x00008000
-const BINCP_FLAG                    = 0x00010000
-const GET_FIXED_FIELDS_FLAG         = 0x00020000
-const FIELD_IN_PART_FUNC_FLAG       = 0x00040000
+const NOT_NULL_FLAG                  = 0x00000001
+const PRI_KEY_FLAG                   = 0x00000002
+const UNIQUE_KEY_FLAG                = 0x00000004
+const MULTIPLE_KEY_FLAG              = 0x00000008
+const BLOB_FLAG                      = 0x00000010
+const UNSIGNED_FLAG                  = 0x00000020
+const ZEROFILL_FLAG                  = 0x00000040
+const BINARY_FLAG                    = 0x00000080
+const ENUM_FLAG                      = 0x00000100
+const AUTO_INCREMENT_FLAG            = 0x00000200
+const TIMESTAMP_FLAG                 = 0x00000400
+const SET_FLAG                       = 0x00000800
+const NO_DEFAULT_VALUE_FLAG          = 0x00001000
+const ON_UPDATE_NOW_FLAG             = 0x00002000
+const NUM_FLAG                       = 0x00004000
+const UNIQUE_FLAG                    = 0x00008000
+const BINCP_FLAG                     = 0x00010000
+const GET_FIXED_FIELDS_FLAG          = 0x00020000
+const FIELD_IN_PART_FUNC_FLAG        = 0x00040000
 
-const CLIENT_LONG_PASSWORD          = 0x00000001
-const CLIENT_FOUND_ROWS             = 0x00000002
-const CLIENT_LONG_FLAG              = 0x00000004
-const CLIENT_CONNECT_WITH_DB        = 0x00000008
-const CLIENT_NO_SCHEMA              = 0x00000010
-const CLIENT_COMPRESS               = 0x00000020
-const CLIENT_ODBC                   = 0x00000040
-const CLIENT_LOCAL_FILES            = 0x00000080
-const CLIENT_IGNORE_SPACE           = 0x00000100
-const CLIENT_PROTOCOL_41            = 0x00000200
-const CLIENT_INTERACTIVE            = 0x00000400
-const CLIENT_SSL                    = 0x00000800
-const CLIENT_IGNORE_SIGPIPE         = 0x00001000
-const CLIENT_TRANSACTIONS           = 0x00002000
-const CLIENT_RESERVED               = 0x00004000
-const CLIENT_SECURE_CONNECTION      = 0x00008000
-const CLIENT_MULTI_STATEMENTS       = 0x00010000
-const CLIENT_MULTI_RESULTS          = 0x00020000
-const CLIENT_PS_MULTI_RESULTS       = 0x00040000
-const CLIENT_PLUGIN_AUTH            = 0x00080000
-const CLIENT_PROGRESS               = 0x20000000
-const CLIENT_SSL_VERIFY_SERVER_CERT = 0x40000000
+const CLIENT_LONG_PASSWORD           = 0x00000001
+const CLIENT_FOUND_ROWS              = 0x00000002
+const CLIENT_LONG_FLAG               = 0x00000004
+const CLIENT_CONNECT_WITH_DB         = 0x00000008
+const CLIENT_NO_SCHEMA               = 0x00000010
+const CLIENT_COMPRESS                = 0x00000020
+const CLIENT_ODBC                    = 0x00000040
+const CLIENT_LOCAL_FILES             = 0x00000080
+const CLIENT_IGNORE_SPACE            = 0x00000100
+const CLIENT_PROTOCOL_41             = 0x00000200
+const CLIENT_INTERACTIVE             = 0x00000400
+const CLIENT_SSL                     = 0x00000800
+const CLIENT_IGNORE_SIGPIPE          = 0x00001000
+const CLIENT_TRANSACTIONS            = 0x00002000
+const CLIENT_RESERVED                = 0x00004000
+const CLIENT_SECURE_CONNECTION       = 0x00008000
+const CLIENT_MULTI_STATEMENTS        = 0x00010000
+const CLIENT_MULTI_RESULTS           = 0x00020000
+const CLIENT_PS_MULTI_RESULTS        = 0x00040000
+const CLIENT_PLUGIN_AUTH             = 0x00080000
+const CLIENT_PROGRESS                = 0x20000000
+const CLIENT_SSL_VERIFY_SERVER_CERT  = 0x40000000
 
-const REFRESH_GRANT                 = 0x00000001
-const REFRESH_LOG                   = 0x00000002
-const REFRESH_TABLES                = 0x00000004
-const REFRESH_HOSTS                 = 0x00000008
-const REFRESH_STATUS                = 0x00000010
-const REFRESH_THREADS               = 0x00000020
-const REFRESH_SLAVE                 = 0x00000040
-const REFRESH_MASTER                = 0x00000080
-const REFRESH_ERROR_LOG             = 0x00000100
-const REFRESH_ENGINE_LOG            = 0x00000200
-const REFRESH_BINARY_LOG            = 0x00000400
-const REFRESH_RELAY_LOG             = 0x00000800
-const REFRESH_GENERAL_LOG           = 0x00001000
-const REFRESH_SLOW_LOG              = 0x00002000
-const REFRESH_READ_LOCK             = 0x00004000
-const REFRESH_CHECKPOINT            = 0x00008000
-const REFRESH_QUERY_CACHE           = 0x00010000
-const REFRESH_QUERY_CACHE_FREE      = 0x00020000
-const REFRESH_DES_KEY_FILE          = 0x00040000
-const REFRESH_USER_RESOURCES        = 0x00080000
-const REFRESH_TABLE_STATS           = 0x00100000
-const REFRESH_INDEX_STATS           = 0x00200000
-const REFRESH_USER_STATS            = 0x00400000
-const REFRESH_FAST                  = 0x80000000
+const REFRESH_GRANT                  = 0x00000001
+const REFRESH_LOG                    = 0x00000002
+const REFRESH_TABLES                 = 0x00000004
+const REFRESH_HOSTS                  = 0x00000008
+const REFRESH_STATUS                 = 0x00000010
+const REFRESH_THREADS                = 0x00000020
+const REFRESH_SLAVE                  = 0x00000040
+const REFRESH_MASTER                 = 0x00000080
+const REFRESH_ERROR_LOG              = 0x00000100
+const REFRESH_ENGINE_LOG             = 0x00000200
+const REFRESH_BINARY_LOG             = 0x00000400
+const REFRESH_RELAY_LOG              = 0x00000800
+const REFRESH_GENERAL_LOG            = 0x00001000
+const REFRESH_SLOW_LOG               = 0x00002000
+const REFRESH_READ_LOCK              = 0x00004000
+const REFRESH_CHECKPOINT             = 0x00008000
+const REFRESH_QUERY_CACHE            = 0x00010000
+const REFRESH_QUERY_CACHE_FREE       = 0x00020000
+const REFRESH_DES_KEY_FILE           = 0x00040000
+const REFRESH_USER_RESOURCES         = 0x00080000
+const REFRESH_TABLE_STATS            = 0x00100000
+const REFRESH_INDEX_STATS            = 0x00200000
+const REFRESH_USER_STATS             = 0x00400000
+const REFRESH_FAST                   = 0x80000000
 
 macro c_str_2_str(c_str)
     return :($c_str == C_NULL ? "" : bytestring($c_str))
@@ -314,13 +272,13 @@ _DB_FIELD_() = _DB_FIELD_(C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL, C_NULL
                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, C_NULL)
 
 type DB_FIELD
-    name::UTF8String
-    org_name::UTF8String
-    table::UTF8String
-    org_table::UTF8String
-    db::UTF8String
-    catalog::UTF8String
-    def::UTF8String
+    name::ByteString
+    org_name::ByteString
+    table::ByteString
+    org_table::ByteString
+    db::ByteString
+    catalog::ByteString
+    def::ByteString
     length::UInt
     max_length::UInt
     flags::UInt32
@@ -332,17 +290,11 @@ type DB_FIELD
 end
 
 map_sql_type(typ, csn, fla) =
-    typearray[typ][(csn == CHAR_SET_BINARY ? 3 : 2) + ((fla & UNSIGNED_FLAG != 0) ? 2 : 0)]
+    typearray[typ][(csn == CHAR_SET_BINARY ? 7 : 5) + ((fla & UNSIGNED_FLAG != 0) ? 1 : 0)]
 
 function db_type_name(field::DB_FIELD)
     typ = typearray[field.type_index]
-    if typ[2] != typ[4] && (field.flags & UNSIGNED_FLAG) != 0
-        string(typ[1]," UNSIGNED")
-    elseif field.charsetnr == CHAR_SET_BINARY
-        typ[1]
-    else
-        textarray[field.type_index]
-    end
+    typ[(field.charsetnr == CHAR_SET_BINARY ? 3 : 1) + ((field.flags & UNSIGNED_FLAG != 0) ? 1 : 0)]
 end
 
 DB_FIELD() = DB_FIELD("", "", "", "", "", 0, 0, 0, 0, 0, Void)
@@ -378,14 +330,14 @@ end
 _DB_CHARSET_INFO_() = _DB_CHARSET_INFO_(0, 0, C_NULL, C_NULL, C_NULL, C_NULL, 0, 0)
 
 type DB_CHARSET_INFO
-    number::UInt
-    state::UInt
-    csname::UTF8String
-    name::UTF8String
-    comment::UTF8String
-    dir::UTF8String
-    mbminlen::UInt
-    mbmaxlen::UInt
+    number::UInt32
+    state::UInt32
+    csname::ByteString
+    name::ByteString
+    comment::ByteString
+    dir::ByteString
+    mbminlen::UInt32
+    mbmaxlen::UInt32
 end
 
 DB_CHARSET_INFO() = DB_CHARSET_INFO(0, 0, "", "", "", "", 0, 0)

--- a/test/test_funcs.jl
+++ b/test/test_funcs.jl
@@ -38,9 +38,9 @@ end
 function drop_test_database()
     db = connect_to_database("root", "", "")
 
-    command = "drop user 'maarten'@'localhost';"
-    command = string(command, "drop user 'michael'@'localhost';")
-    command = string(command, "drop database db_test;")
+    command = """drop user 'maarten'@'localhost';
+		 drop user 'michael'@'localhost';
+    		 drop database db_test;"""
     rc = DB.real_query(db, command)
     rc != DB_OK && println(DB.last_error(db))
     @test rc == DB_OK
@@ -52,21 +52,32 @@ function prepare_database()
     db = connect_to_database("root", "", "")
     # Check to see if we already have a database 'db_test'
     command = "show databases like 'db_test';"
+    println("got here 1!")
     rc = DB.real_query(db, command)
+    println("got here 2!")
     rc != DB_OK && println(DB.last_error(db))
     @test rc == DB_OK
     fc = DB.field_count(db)
+    println("got here 3!")
     @test fc == 1
     reshndl = DB.use_result(db)
+    println("got here 4!")
     @test reshndl.ptr != C_NULL
     rowCount = 0
+    println("result type\n")
+    dump(reshndl)
+    println()
     while length(DB.fetch_row(reshndl)) != 0
         rowCount += 1
+        println("got here 5! $rowCount")
     end
 
+    println("got here 6!")
     DB.free_result(reshndl)
+    println("got here 7!")
 
     DB.close(db)
+    println("got here 8!")
     if rowCount > 0
         println("Database 'db_test' found")
         println("\tRecreating...")


### PR DESCRIPTION
This cleans up the interface, to pretty much eliminate the MYSQL name from the external API
(although it still uses the mysql_* C code from the MySQL or MariaDB library)
This also makes it easier to parse things differently.